### PR TITLE
feat(concepts): `numeric_constant`

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -61,7 +61,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DBUILD_TESTING=ON -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_COMPILER=${{matrix.cxx-compiler}} -DPOSU_ENABLE_TESTING=ON -DPOSU_ENABLE_WALL=ON -DPOSU_ENABLE_WERROR=ON
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DBUILD_TESTING=ON -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_COMPILER=${{matrix.cxx-compiler}} -DPOSU_ENABLE_TESTING=ON -DPOSU_ENABLE_WALL=ON -DPOSU_ENABLE_WERROR=ON -DPOSU_ENABLE_DETAILED_CONCEPTS_DIAGNOSTICS=ON
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ find_program(POSU_CLANG_TIDY   clang-tidy)
 
 set(
     POSU_HPP_FILES
+        ${CMAKE_CURRENT_LIST_DIR}/posu/concepts.hpp
         ${CMAKE_CURRENT_LIST_DIR}/posu/type_list.hpp
         ${CMAKE_CURRENT_LIST_DIR}/posu/type_ratio.hpp
         ${CMAKE_CURRENT_LIST_DIR}/posu/utility.hpp
@@ -115,6 +116,11 @@ if(BUILD_TESTING AND POSU_ENABLE_TESTING)
     target_link_libraries(test_arith_tuple PRIVATE Catch2::Catch2)
     target_link_libraries(test_arith_tuple PRIVATE posu)
     add_test(NAME test_arith_tuple COMMAND test_arith_tuple)
+
+    add_executable(test_concepts ${CMAKE_CURRENT_LIST_DIR}/test/test_concepts.cpp)
+    target_link_libraries(test_concepts PRIVATE Catch2::Catch2)
+    target_link_libraries(test_concepts PRIVATE posu)
+    add_test(NAME test_concepts COMMAND test_concepts)
 
     add_executable(test_zip_range ${CMAKE_CURRENT_LIST_DIR}/test/test_zip_range.cpp)
     target_link_libraries(test_zip_range PRIVATE Catch2::Catch2)

--- a/posu/concepts.hpp
+++ b/posu/concepts.hpp
@@ -1,0 +1,57 @@
+#ifndef POSU_CONCEPTS_HPP
+#define POSU_CONCEPTS_HPP
+
+#include <concepts>
+
+namespace posu {
+
+    /**
+     * @brief A type wrapping a compile-time constant.
+     *
+     * Modeled after `std::integral_constant`.
+     *
+     * @tparam T The type to check against this concept.
+     */
+    template<typename T>
+    concept meta_value_constant = std::default_initializable<T> &&
+        std::same_as<const typename T::value_type, decltype(T::value)> &&
+        std::same_as<typename T::type, T> && std::convertible_to<T, typename T::value_type> &&
+        std::is_invocable_r_v<typename T::value_type, T>;
+
+    /**
+     * @brief An integral compile-time constant.
+     *
+     * @tparam T The type to check against this concept.
+     */
+    template<typename T>
+    concept integral_constant = meta_value_constant<T> && requires
+    {
+        // clang-format off
+        { T::value } -> std::integral;
+        // clang-format on
+    };
+
+    /**
+     * @brief A floating point compile-time constant.
+     *
+     * @tparam T The type to check against this concept.
+     */
+    template<typename T>
+    concept floating_point_constant = meta_value_constant<T> && requires
+    {
+        // clang-format off
+        { T::value } -> std::floating_point;
+        // clang-format on
+    };
+
+    /**
+     * @brief A numeric compile-time constant.
+     *
+     * @tparam T The type to check against this concept.
+     */
+    template<typename T>
+    concept numeric_constant = integral_constant<T> || floating_point_constant<T>;
+
+} // namespace posu
+
+#endif

--- a/posu/concepts.hpp
+++ b/posu/concepts.hpp
@@ -24,12 +24,7 @@ namespace posu {
      * @tparam T The type to check against this concept.
      */
     template<typename T>
-    concept integral_constant = meta_value_constant<T> && requires
-    {
-        // clang-format off
-        { T::value } -> std::integral;
-        // clang-format on
-    };
+    concept integral_constant = meta_value_constant<T> && std::integral<typename T::value_type>;
 
     /**
      * @brief A floating point compile-time constant.
@@ -37,12 +32,8 @@ namespace posu {
      * @tparam T The type to check against this concept.
      */
     template<typename T>
-    concept floating_point_constant = meta_value_constant<T> && requires
-    {
-        // clang-format off
-        { T::value } -> std::floating_point;
-        // clang-format on
-    };
+    concept floating_point_constant =
+        meta_value_constant<T> && std::floating_point<typename T::value_type>;
 
     /**
      * @brief A numeric compile-time constant.

--- a/test/test_concepts.cpp
+++ b/test/test_concepts.cpp
@@ -1,0 +1,9 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include "posu/concepts.hpp"
+
+TEST_CASE("Standard integral constant values", "[integra_constant]")
+{
+    static_assert(posu::integral_constant<std::true_type>);
+}


### PR DESCRIPTION
Introduce concepts modeled after `std::integral_constant`, and generalize to floating point types.