### PR TITLE
feat(posu): `basic_string_literal`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ set(
     POSU_HPP_FILES
         ${CMAKE_CURRENT_LIST_DIR}/posu/concepts.hpp
         ${CMAKE_CURRENT_LIST_DIR}/posu/ratio.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/posu/string_literal.hpp
         ${CMAKE_CURRENT_LIST_DIR}/posu/utility.hpp
         ${CMAKE_CURRENT_LIST_DIR}/posu/vmath.hpp
         ${CMAKE_CURRENT_LIST_DIR}/posu/zip_range.hpp
@@ -250,6 +251,7 @@ set(
         ${CMAKE_CURRENT_LIST_DIR}/test/test_concepts.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test/test_posu.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test/test_ratio.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/test/test_string_literal.cpp
         ${CMAKE_CURRENT_LIST_DIR}/test/test_zip_range.cpp
 )
 

--- a/posu/ipp/string_literal.ipp
+++ b/posu/ipp/string_literal.ipp
@@ -1,0 +1,21 @@
+
+template<typename CharT, std::size_t N>
+constexpr posu::basic_string_literal<CharT, N>::basic_string_literal(const CharT (&arr)[N]) noexcept
+    : basic_string_literal{arr, std::make_index_sequence<N>{}}
+{
+}
+
+template<typename CharT, std::size_t N>
+template<std::size_t... I>
+constexpr posu::basic_string_literal<CharT, N>::basic_string_literal(
+    const CharT (&arr)[N],
+    std::index_sequence<I...> /*unused*/) noexcept
+    : basic_string_literal{arr[I]...}
+{
+}
+
+template<typename CharT, std::size_t N>
+template<typename... C>
+constexpr posu::basic_string_literal<CharT, N>::basic_string_literal(C... c) noexcept : value{c...}
+{
+}

--- a/posu/string_literal.hpp
+++ b/posu/string_literal.hpp
@@ -2,6 +2,7 @@
 #define POSU_STRING_LITERAL_HPP
 
 #include <type_traits>
+#include <utility>
 
 namespace posu {
     template<typename CharT, std::size_t N>
@@ -22,6 +23,7 @@ namespace posu {
         static constexpr auto npos = static_cast<size_type>(-1);
 
         constexpr basic_string_literal() noexcept requires(N == 0) = default;
+        constexpr basic_string_literal(const CharT (&arr)[N]) noexcept;
 
         [[nodiscard]] constexpr operator const storage_type&() const noexcept { return value; }
 
@@ -36,6 +38,14 @@ namespace posu {
         [[nodiscard]] constexpr auto cend() const noexcept -> const_iterator { return data() + N; }
 
         const storage_type value;
+
+    private:
+        template<std::size_t... I>
+        constexpr basic_string_literal(
+            const CharT (&arr)[N],
+            std::index_sequence<I...> /*unused*/) noexcept;
+        template<typename... C>
+        constexpr basic_string_literal(C... c) noexcept;
     };
 
     template<typename CharT, std::size_t N>
@@ -53,5 +63,7 @@ namespace posu {
     using u32string_literal = basic_string_literal<char32_t, N>;
 
 } // namespace posu
+
+#include "posu/ipp/string_literal.ipp"
 
 #endif // #ifndef POSU_STRING_LITERAL_HPP

--- a/posu/string_literal.hpp
+++ b/posu/string_literal.hpp
@@ -5,35 +5,75 @@
 #include <utility>
 
 namespace posu {
+
+    /**
+     * @brief String literal type.
+     *
+     * @tparam CharT The string character type.
+     * @tparam N     The number of characters in the string.
+     */
     template<typename CharT, std::size_t N>
     struct basic_string_literal {
     private:
         using storage_type = CharT[N];
 
     public:
-        using value_type      = CharT;
-        using size_type       = std::size_t;
-        using const_reference = const value_type&;
-        using reference       = const_reference;
-        using const_pointer   = const value_type*;
-        using pointer         = const_pointer;
-        using iterator        = pointer;
-        using const_iterator  = const_pointer;
+        using value_type      = CharT;             //!< Character type.
+        using size_type       = std::size_t;       //!< String length type.
+        using const_reference = const value_type&; //!< Immutable character reference.
+        using reference       = const_reference;   //!< Mutable character reference.
+        using const_pointer   = const value_type*; //!< Immutable character pointer.
+        using pointer         = const_pointer;     //!< Mutable character pointer.
+        using iterator        = pointer;           //!< Mutable character iterator.
+        using const_iterator  = const_pointer;     //!< Immutable character iterator.
 
+        /**
+         * @brief Default-construct zero-length string literal.
+         */
         constexpr basic_string_literal() noexcept requires(N == 0) = default;
+
+        /**
+         * @brief Construct string literal from constant character array.
+         *
+         * @param arr A constant character array to initialize from.
+         */
         constexpr basic_string_literal(const CharT (&arr)[N]) noexcept;
 
-        [[nodiscard]] constexpr operator const storage_type&() const noexcept { return value; }
-
+        /**
+         * @name Literal Access
+         *
+         * @brief Access as a string literal.
+         *
+         * @return Returns the represented string literal.
+         *
+         * @{
+         */
+        [[nodiscard]] constexpr      operator const storage_type&() const noexcept { return value; }
         [[nodiscard]] constexpr auto data() const noexcept -> const_pointer { return value; }
         [[nodiscard]] constexpr auto c_str() const noexcept -> const_pointer { return value; }
+        //! @}
 
+        /**
+         * @brief Obtain the string literal length, including the null terminator.
+         *
+         * @return Returns the string literal length.
+         */
         [[nodiscard]] constexpr auto size() const noexcept -> size_type { return N; }
 
+        /**
+         * @name Iterators
+         *
+         * @brief Obtain iterators into the string literal.
+         *
+         * @return Returns the requested iterator.
+         *
+         * @{
+         */
         [[nodiscard]] constexpr auto begin() const noexcept -> const_iterator { return data(); }
         [[nodiscard]] constexpr auto cbegin() const noexcept -> const_iterator { return data(); }
         [[nodiscard]] constexpr auto end() const noexcept -> const_iterator { return data() + N; }
         [[nodiscard]] constexpr auto cend() const noexcept -> const_iterator { return data() + N; }
+        //! @}
 
         const storage_type value;
 
@@ -46,9 +86,22 @@ namespace posu {
         constexpr basic_string_literal(C... c) noexcept;
     };
 
+    /**
+     * @brief Deduction from string literal.
+     *
+     * @tparam CharT The string character type.
+     * @tparam N     The string literal length.
+     */
     template<typename CharT, std::size_t N>
     basic_string_literal(const CharT (&)[N]) -> basic_string_literal<std::remove_cv_t<CharT>, N>;
 
+    /**
+     * @brief Convenience aliases for common character types.
+     *
+     * @tparam N The number of characters in the literal.
+     *
+     * @{
+     */
     template<std::size_t N>
     using string_literal = basic_string_literal<char, N>;
     template<std::size_t N>
@@ -59,6 +112,7 @@ namespace posu {
     using u16string_literal = basic_string_literal<char16_t, N>;
     template<std::size_t N>
     using u32string_literal = basic_string_literal<char32_t, N>;
+    //! @}
 
 } // namespace posu
 

--- a/posu/string_literal.hpp
+++ b/posu/string_literal.hpp
@@ -41,6 +41,17 @@ namespace posu {
     template<typename CharT, std::size_t N>
     basic_string_literal(const CharT (&)[N]) -> basic_string_literal<std::remove_cv_t<CharT>, N>;
 
+    template<std::size_t N>
+    using string_literal = basic_string_literal<char, N>;
+    template<std::size_t N>
+    using wstring_literal = basic_string_literal<wchar_t, N>;
+    template<std::size_t N>
+    using u8string_literal = basic_string_literal<char8_t, N>;
+    template<std::size_t N>
+    using u16string_literal = basic_string_literal<char16_t, N>;
+    template<std::size_t N>
+    using u32string_literal = basic_string_literal<char32_t, N>;
+
 } // namespace posu
 
 #endif // #ifndef POSU_STRING_LITERAL_HPP

--- a/posu/string_literal.hpp
+++ b/posu/string_literal.hpp
@@ -1,0 +1,46 @@
+#ifndef POSU_STRING_LITERAL_HPP
+#define POSU_STRING_LITERAL_HPP
+
+#include <type_traits>
+
+namespace posu {
+    template<typename CharT, std::size_t N>
+    struct basic_string_literal {
+    private:
+        using storage_type = CharT[N];
+
+    public:
+        using value_type      = CharT;
+        using size_type       = std::size_t;
+        using const_reference = const value_type&;
+        using reference       = const_reference;
+        using const_pointer   = const value_type*;
+        using pointer         = const_pointer;
+        using iterator        = pointer;
+        using const_iterator  = const_pointer;
+
+        static constexpr auto npos = static_cast<size_type>(-1);
+
+        constexpr basic_string_literal() noexcept requires(N == 0) = default;
+
+        [[nodiscard]] constexpr operator const storage_type&() const noexcept { return value; }
+
+        [[nodiscard]] constexpr auto data() const noexcept -> const_pointer { return value; }
+        [[nodiscard]] constexpr auto c_str() const noexcept -> const_pointer { return value; }
+
+        [[nodiscard]] constexpr auto size() const noexcept -> size_type { return N; }
+
+        [[nodiscard]] constexpr auto begin() const noexcept -> const_iterator { return data(); }
+        [[nodiscard]] constexpr auto cbegin() const noexcept -> const_iterator { return data(); }
+        [[nodiscard]] constexpr auto end() const noexcept -> const_iterator { return data() + N; }
+        [[nodiscard]] constexpr auto cend() const noexcept -> const_iterator { return data() + N; }
+
+        const storage_type value;
+    };
+
+    template<typename CharT, std::size_t N>
+    basic_string_literal(const CharT (&)[N]) -> basic_string_literal<std::remove_cv_t<CharT>, N>;
+
+} // namespace posu
+
+#endif // #ifndef POSU_STRING_LITERAL_HPP

--- a/posu/string_literal.hpp
+++ b/posu/string_literal.hpp
@@ -20,8 +20,6 @@ namespace posu {
         using iterator        = pointer;
         using const_iterator  = const_pointer;
 
-        static constexpr auto npos = static_cast<size_type>(-1);
-
         constexpr basic_string_literal() noexcept requires(N == 0) = default;
         constexpr basic_string_literal(const CharT (&arr)[N]) noexcept;
 

--- a/test/test_string_literal.cpp
+++ b/test/test_string_literal.cpp
@@ -1,1 +1,19 @@
 #include "posu/string_literal.hpp"
+
+#define CATCH_CONFIG_PREFIX_ALL
+
+#include <catch2/catch.hpp>
+
+namespace {
+
+    template<posu::basic_string_literal String>
+    struct test_type {
+    };
+
+} // namespace
+
+CATCH_TEST_CASE("use `string_literal` as NTTP")
+{
+    CATCH_CHECK(std::same_as<test_type<"this">, test_type<"this">>);
+    CATCH_CHECK(!std::same_as<test_type<"this">, test_type<"that">>);
+}

--- a/test/test_string_literal.cpp
+++ b/test/test_string_literal.cpp
@@ -1,0 +1,1 @@
+#include "posu/string_literal.hpp"


### PR DESCRIPTION
Introduce `basic_string_literal`, based on [P1378R0](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1378r0.html) and with NTTP support vis-a-vis [P0259R0](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0259r0.pdf).