### PR TITLE
feat(meta)!: value-like syntax for `meta` types

### DIFF
--- a/posu/meta/algorithm.hpp
+++ b/posu/meta/algorithm.hpp
@@ -15,13 +15,13 @@ namespace posu::meta {
     [[nodiscard]] constexpr bool none_of(list<Types...> /*unused*/ = {}) noexcept;
 
     template<typename List, template<typename> typename Predicate>
-    concept list_with_all = is_list_v<List> && all_of<Predicate>(List{});
+    concept list_with_all = list_type<List> && all_of<Predicate>(List{});
 
     template<typename List, template<typename> typename Predicate>
-    concept list_with_any = is_list_v<List> && any_of<Predicate>(List{});
+    concept list_with_any = list_type<List> && any_of<Predicate>(List{});
 
     template<typename List, template<typename> typename Predicate>
-    concept list_with_no = is_list_v<List> && none_of<Predicate>(List{});
+    concept list_with_no = list_type<List> && none_of<Predicate>(List{});
 
     template<template<typename> typename Predicate, typename... Types>
     concept matches_all = (Predicate<Types>::value && ...);

--- a/posu/meta/ipp/list.ipp
+++ b/posu/meta/ipp/list.ipp
@@ -193,8 +193,8 @@ template<std::size_t Begin, std::size_t End>
 template<posu::meta::list_type TypeList, typename... Args>
 [[nodiscard]] constexpr auto posu::meta::make_tuple_from(
     TypeList /*unused*/,
-    Args&&... args) noexcept(std::is_nothrow_constructible_v<tuple_from_t<TypeList>>)
-    -> tuple_from_t<TypeList>
+    Args&&... args) noexcept(std::is_nothrow_constructible_v<tuple_from<TypeList>, Args...>)
+    -> tuple_from<TypeList>
 {
     return TypeList::make_tuple(std::forward<Args>(args)...);
 }
@@ -202,8 +202,8 @@ template<posu::meta::list_type TypeList, typename... Args>
 template<posu::meta::list_type TypeList, typename... Args>
 [[nodiscard]] constexpr auto posu::meta::make_variant_from(
     TypeList /*unused*/,
-    Args&&... args) noexcept(std::is_nothrow_constructible_v<variant_from_t<TypeList>>)
-    -> variant_from_t<TypeList>
+    Args&&... args) noexcept(std::is_nothrow_constructible_v<variant_from<TypeList>, Args...>)
+    -> variant_from<TypeList>
 {
     return TypeList::make_variant(std::forward<Args>(args)...);
 }

--- a/posu/meta/ipp/list.ipp
+++ b/posu/meta/ipp/list.ipp
@@ -1,123 +1,123 @@
 
-namespace posu::meta {
+namespace posu::meta::detail {
 
-    namespace detail {
+    template<typename... Lists>
+    using concatenate_impl_t = typename concatenate_impl<Lists...>::type;
 
-        template<typename... Lists>
-        using concatenate_impl_t = typename concatenate_impl<Lists...>::type;
+    template<typename... LhsTypes, typename... RhsTypes>
+    struct concatenate_impl<list<LhsTypes...>, list<RhsTypes...>> {
+        using type = list<LhsTypes..., RhsTypes...>;
+    };
 
-        template<typename... LhsTypes, typename... RhsTypes>
-        struct concatenate_impl<list<LhsTypes...>, list<RhsTypes...>> {
-            using type = list<LhsTypes..., RhsTypes...>;
-        };
+    template<typename First, typename Second, typename... Rest>
+    struct concatenate_impl<First, Second, Rest...>
+        : concatenate_impl<concatenate_impl_t<First, Second>, Rest...> {
+    };
 
-        template<typename First, typename Second, typename... Rest>
-        struct concatenate_impl<First, Second, Rest...>
-            : concatenate_impl<concatenate_impl_t<First, Second>, Rest...> {
-        };
+    template<typename... Types, typename T>
+    struct prepend_impl<list<Types...>, T> : concatenate_impl<list<T>, list<Types...>> {
+    };
 
-        template<typename... Types, typename T>
-        struct prepend_impl<list<Types...>, T> : concatenate_impl<list<T>, list<Types...>> {
-        };
+    template<typename... Types, typename T>
+    struct prepend_impl<list<Types...>, list<T>> : concatenate_impl<list<T>, list<Types...>> {
+    };
 
-        template<typename... Types, typename T>
-        struct prepend_impl<list<Types...>, list<T>> : concatenate_impl<list<T>, list<Types...>> {
-        };
+    template<typename... Types, typename T>
+    struct append_impl<list<Types...>, T> : concatenate_impl<list<Types...>, list<T>> {
+    };
 
-        template<typename... Types, typename T>
-        struct append_impl<list<Types...>, T> : concatenate_impl<list<Types...>, list<T>> {
-        };
+    template<typename... Types, typename T>
+    struct append_impl<list<Types...>, list<T>> : concatenate_impl<list<Types...>, list<T>> {
+    };
 
-        template<typename... Types, typename T>
-        struct append_impl<list<Types...>, list<T>> : concatenate_impl<list<Types...>, list<T>> {
-        };
+    template<typename First, typename... Rest>
+    struct pop_front_impl<list<First, Rest...>> {
+        using type = list<Rest...>;
+    };
 
-        template<typename First, typename... Rest>
-        struct pop_front_impl<list<First, Rest...>> {
-            using type = list<Rest...>;
-        };
+    template<typename Type>
+    struct pop_back_impl<list<Type>> {
+        using type = list<>;
+    };
 
-        template<typename Type>
-        struct pop_back_impl<list<Type>> {
-            using type = list<>;
-        };
+    template<typename First, typename Second>
+    struct pop_back_impl<list<First, Second>> {
+        using type = list<First>;
+    };
 
-        template<typename First, typename Second>
-        struct pop_back_impl<list<First, Second>> {
-            using type = list<First>;
-        };
+    template<typename First, typename... Rest>
+    struct pop_back_impl<list<First, Rest...>> : prepend_impl<pop_back<list<Rest...>>, First> {
+    };
 
-        template<typename First, typename... Rest>
-        struct pop_back_impl<list<First, Rest...>> : prepend_impl<pop_back<list<Rest...>>, First> {
-        };
+    template<typename List, std::size_t... I>
+    struct take_items<List, std::index_sequence<I...>> {
+        using type = list<typename List::template at<I>...>;
+    };
 
-        template<typename List, std::size_t... I>
-        struct take_items<List, std::index_sequence<I...>> {
-            using type = list<typename List::template at<I>...>;
-        };
-
-        template<typename List, typename T, std::size_t I>
-        [[nodiscard]] constexpr auto find_impl_fn() noexcept -> std::size_t
-        {
-            if constexpr(I < std::tuple_size_v<List>) {
-                if constexpr(std::same_as<std::tuple_element_t<I, List>, T>) {
-                    return I;
-                }
-                else {
-                    return find_impl_fn<List, T, I + 1>();
-                }
+    template<typename List, typename T, std::size_t I>
+    [[nodiscard]] constexpr auto find_impl_fn() noexcept -> std::size_t
+    {
+        if constexpr(I < std::tuple_size_v<List>) {
+            if constexpr(std::same_as<std::tuple_element_t<I, List>, T>) {
+                return I;
             }
-
-            return I;
+            else {
+                return find_impl_fn<List, T, I + 1>();
+            }
         }
 
-        template<typename List, std::size_t I, typename T>
-        struct insert_impl {
-            using type =
-                concatenate<push_back<first<List, I>, T>, last<List, std::tuple_size_v<List> - I>>;
-        };
-
-        template<typename List, std::size_t I>
-        struct remove_impl {
-            using type =
-                concatenate<first<List, I>, pop_front<last<List, std::tuple_size_v<List> - I>>>;
-        };
-
-        template<typename List>
-        struct remove_impl<List, 0> {
-            using type = pop_front<List>;
-        };
-
-    } // namespace detail
-
-    template<typename... Types>
-    template<typename... Args>
-    [[nodiscard]] constexpr auto list<Types...>::make_tuple(Args&&... args) noexcept(
-        std::is_nothrow_constructible_v<tuple, Args...>) -> tuple
-    {
-        return std::make_tuple(std::forward<Args>(args)...);
+        return I;
     }
 
-    template<typename... Types>
-    template<typename... Args>
-    [[nodiscard]] constexpr auto list<Types...>::make_variant(Args&&... args) noexcept(
-        std::is_nothrow_constructible_v<variant, Args...>) -> variant
-    {
-        return variant(std::forward<Args>(args)...);
-    }
+    template<typename List, std::size_t I, typename T>
+    struct insert_impl {
+        using type =
+            concatenate<push_back<first<List, I>, T>, last<List, std::tuple_size_v<List> - I>>;
+    };
 
-    template<list_type TypeList, typename... Args>
-    [[nodiscard]] constexpr auto make_tuple_from(TypeList /*unused*/, Args&&... args) noexcept(
-        std::is_nothrow_constructible_v<tuple_from_t<TypeList>>) -> tuple_from_t<TypeList>
-    {
-        return TypeList::make_tuple(std::forward<Args>(args)...);
-    }
+    template<typename List, std::size_t I>
+    struct remove_impl {
+        using type =
+            concatenate<first<List, I>, pop_front<last<List, std::tuple_size_v<List> - I>>>;
+    };
 
-    template<list_type TypeList, typename... Args>
-    [[nodiscard]] constexpr auto make_variant_from(TypeList /*unused*/, Args&&... args) noexcept(
-        std::is_nothrow_constructible_v<variant_from_t<TypeList>>) -> variant_from_t<TypeList>
-    {
-        return TypeList::make_variant(std::forward<Args>(args)...);
-    }
+    template<typename List>
+    struct remove_impl<List, 0> {
+        using type = pop_front<List>;
+    };
 
-} // namespace posu::meta
+} // namespace posu::meta::detail
+
+template<typename... Types>
+template<typename... Args>
+[[nodiscard]] constexpr auto posu::meta::list<Types...>::make_tuple(Args&&... args) noexcept(
+    std::is_nothrow_constructible_v<tuple, Args...>) -> tuple
+{
+    return std::make_tuple(std::forward<Args>(args)...);
+}
+
+template<typename... Types>
+template<typename... Args>
+[[nodiscard]] constexpr auto posu::meta::list<Types...>::make_variant(Args&&... args) noexcept(
+    std::is_nothrow_constructible_v<variant, Args...>) -> variant
+{
+    return variant(std::forward<Args>(args)...);
+}
+
+template<posu::meta::list_type TypeList, typename... Args>
+[[nodiscard]] constexpr auto posu::meta::make_tuple_from(
+    TypeList /*unused*/,
+    Args&&... args) noexcept(std::is_nothrow_constructible_v<tuple_from_t<TypeList>>)
+    -> tuple_from_t<TypeList>
+{
+    return TypeList::make_tuple(std::forward<Args>(args)...);
+}
+
+template<posu::meta::list_type TypeList, typename... Args>
+[[nodiscard]] constexpr auto posu::meta::make_variant_from(
+    TypeList /*unused*/,
+    Args&&... args) noexcept(std::is_nothrow_constructible_v<variant_from_t<TypeList>>)
+    -> variant_from_t<TypeList>
+{
+    return TypeList::make_variant(std::forward<Args>(args)...);
+}

--- a/posu/meta/ipp/list.ipp
+++ b/posu/meta/ipp/list.ipp
@@ -30,19 +30,18 @@ namespace posu::meta::detail {
         return std::index_sequence<(I + Offset)...>{};
     }
 
-    template<typename List, typename T, std::size_t I>
-    [[nodiscard]] constexpr auto find_impl_fn() noexcept -> std::size_t
+    template<typename T, std::size_t I = 0, list_type List>
+    [[nodiscard]] constexpr auto find_impl(List l) noexcept
     {
-        if constexpr(I < std::tuple_size_v<List>) {
-            if constexpr(std::same_as<std::tuple_element_t<I, List>, T>) {
-                return I;
-            }
-            else {
-                return find_impl_fn<List, T, I + 1>();
-            }
+        if constexpr(I == l.size()) {
+            return I;
         }
-
-        return I;
+        else if constexpr(std::same_as<at<List, I>, T>) {
+            return I;
+        }
+        else {
+            return find_impl<T, I + 1>(l);
+        }
     }
 
     template<typename List, std::size_t I, typename T>
@@ -144,6 +143,12 @@ template<std::size_t N>
 [[nodiscard]] constexpr auto posu::meta::last(list_type auto l) noexcept requires(N <= l.size())
 {
     return take_range<l.size() - N, l.size()>(l);
+}
+
+template<typename T>
+[[nodiscard]] constexpr auto posu::meta::find(list_type auto l) noexcept
+{
+    return detail::find_impl<T>(l);
 }
 
 template<posu::meta::list_type TypeList, typename... Args>

--- a/posu/meta/ipp/list.ipp
+++ b/posu/meta/ipp/list.ipp
@@ -12,26 +12,6 @@ namespace posu::meta::detail {
         return concatenate_impl(list<LTypes..., RTypes...>{}, part...);
     }
 
-    template<typename... Types, typename T>
-    struct prepend_impl<list<Types...>, T> {
-        using type = decltype(concatenate(list<T>{}, list<Types...>{}));
-    };
-
-    template<typename... Types, typename T>
-    struct prepend_impl<list<Types...>, list<T>> {
-        using type = decltype(concatenate(list<T>{}, list<Types...>{}));
-    };
-
-    template<typename... Types, typename T>
-    struct append_impl<list<Types...>, T> {
-        using type = decltype(concatenate(list<Types...>{}, list<T>{}));
-    };
-
-    template<typename... Types, typename T>
-    struct append_impl<list<Types...>, list<T>> {
-        using type = decltype(concatenate(list<Types...>{}, list<T>{}));
-    };
-
     template<typename First, typename... Rest>
     struct pop_front_impl<list<First, Rest...>> {
         using type = list<Rest...>;
@@ -48,7 +28,8 @@ namespace posu::meta::detail {
     };
 
     template<typename First, typename... Rest>
-    struct pop_back_impl<list<First, Rest...>> : prepend_impl<pop_back<list<Rest...>>, First> {
+    struct pop_back_impl<list<First, Rest...>> {
+        using type = decltype(concatenate(list<First>{}, pop_back<list<Rest...>>{}));
     };
 
     template<typename List, std::size_t... I>
@@ -74,7 +55,7 @@ namespace posu::meta::detail {
     template<typename List, std::size_t I, typename T>
     struct insert_impl {
         using type = decltype(concatenate(
-            push_back<first<List, I>, T>{},
+            push_back<T>(first<List, I>{}),
             last<List, std::tuple_size_v<List> - I>{}));
     };
 
@@ -111,6 +92,18 @@ template<typename... Args>
 [[nodiscard]] constexpr auto posu::meta::concatenate(list_type auto... part) noexcept
 {
     return detail::concatenate_impl(part...);
+}
+
+template<typename T, typename... Listed>
+[[nodiscard]] constexpr auto posu::meta::push_front(list<Listed...> /*unused*/) noexcept
+{
+    return list<T, Listed...>{};
+}
+
+template<typename T, typename... Listed>
+[[nodiscard]] constexpr auto posu::meta::push_back(list<Listed...> /*unused*/) noexcept
+{
+    return list<Listed..., T>{};
 }
 
 template<posu::meta::list_type TypeList, typename... Args>

--- a/posu/meta/ipp/list.ipp
+++ b/posu/meta/ipp/list.ipp
@@ -174,6 +174,12 @@ posu::meta::remove(list_type auto l, std::index_sequence<I...> i) noexcept
     }
 }
 
+template<typename T>
+[[nodiscard]] constexpr bool posu::meta::contains(list_type auto l) noexcept
+{
+    return find<T>(l) != l.size();
+}
+
 template<std::size_t Begin, std::size_t End>
 [[nodiscard]] constexpr auto posu::meta::remove_range(
     list_type auto l,

--- a/posu/meta/ipp/list.ipp
+++ b/posu/meta/ipp/list.ipp
@@ -47,16 +47,14 @@ namespace posu::meta::detail {
 
     template<typename List, std::size_t I, typename T>
     struct insert_impl {
-        using type = decltype(concatenate(
-            push_back<T>(first<List, I>{}),
-            last<List, std::tuple_size_v<List> - I>{}));
+        using type =
+            decltype(concatenate(first<I>(List{}), list<T>{}, last<List::size() - I>(List{})));
     };
 
     template<typename List, std::size_t I>
     struct remove_impl {
-        using type = decltype(concatenate(
-            first<List, I>{},
-            pop_front(last<List, std::tuple_size_v<List> - I>{})));
+        using type =
+            decltype(concatenate(first<I>(List{}), pop_front(last<List::size() - I>(List{}))));
     };
 
     template<typename List>
@@ -134,6 +132,18 @@ template<std::size_t Begin, std::size_t End>
     requires((Begin <= l.size()) && (End <= l.size()) && (Begin <= End))
 {
     return take(l, detail::offset<Begin>(std::make_index_sequence<End - Begin>{}));
+}
+
+template<std::size_t N, typename... T>
+[[nodiscard]] constexpr auto posu::meta::first(list<T...> l) noexcept requires(N <= l.size())
+{
+    return take(l, std::make_index_sequence<N>{});
+}
+
+template<std::size_t N>
+[[nodiscard]] constexpr auto posu::meta::last(list_type auto l) noexcept requires(N <= l.size())
+{
+    return take_range<l.size() - N, l.size()>(l);
 }
 
 template<posu::meta::list_type TypeList, typename... Args>

--- a/posu/meta/ipp/list.ipp
+++ b/posu/meta/ipp/list.ipp
@@ -106,16 +106,14 @@ namespace posu::meta {
         return variant(std::forward<Args>(args)...);
     }
 
-    template<typename TypeList, typename... Args>
-        requires is_list_v<TypeList>
+    template<list_type TypeList, typename... Args>
     [[nodiscard]] constexpr auto make_tuple_from(TypeList /*unused*/, Args&&... args) noexcept(
         std::is_nothrow_constructible_v<tuple_from_t<TypeList>>) -> tuple_from_t<TypeList>
     {
         return TypeList::make_tuple(std::forward<Args>(args)...);
     }
 
-    template<typename TypeList, typename... Args>
-        requires is_list_v<TypeList>
+    template<list_type TypeList, typename... Args>
     [[nodiscard]] constexpr auto make_variant_from(TypeList /*unused*/, Args&&... args) noexcept(
         std::is_nothrow_constructible_v<variant_from_t<TypeList>>) -> variant_from_t<TypeList>
     {

--- a/posu/meta/ipp/list.ipp
+++ b/posu/meta/ipp/list.ipp
@@ -24,10 +24,11 @@ namespace posu::meta::detail {
         return push_front<First>(pop_back(list<Second, Rest...>{}));
     }
 
-    template<typename List, std::size_t... I>
-    struct take_items<List, std::index_sequence<I...>> {
-        using type = list<typename List::template at<I>...>;
-    };
+    template<std::size_t Offset, std::size_t... I>
+    [[nodiscard]] constexpr auto offset(std::index_sequence<I...> /*unused*/) noexcept
+    {
+        return std::index_sequence<(I + Offset)...>{};
+    }
 
     template<typename List, typename T, std::size_t I>
     [[nodiscard]] constexpr auto find_impl_fn() noexcept -> std::size_t
@@ -119,6 +120,20 @@ template<typename T, typename... Listed>
     else {
         return detail::pop_back_impl(l);
     }
+}
+
+template<posu::meta::list_type List, std::size_t... I>
+[[nodiscard]] constexpr auto posu::meta::take(List l, std::index_sequence<I...> /*unused*/) noexcept
+    requires((I < l.size()) && ...)
+{
+    return list<at<List, I>...>{};
+}
+
+template<std::size_t Begin, std::size_t End>
+[[nodiscard]] constexpr auto posu::meta::take_range(list_type auto l) noexcept
+    requires((Begin <= l.size()) && (End <= l.size()) && (Begin <= End))
+{
+    return take(l, detail::offset<Begin>(std::make_index_sequence<End - Begin>{}));
 }
 
 template<posu::meta::list_type TypeList, typename... Args>

--- a/posu/meta/ipp/list.ipp
+++ b/posu/meta/ipp/list.ipp
@@ -44,12 +44,6 @@ namespace posu::meta::detail {
         }
     }
 
-    template<typename List, std::size_t I, typename T>
-    struct insert_impl {
-        using type =
-            decltype(concatenate(first<I>(List{}), list<T>{}, last<List::size() - I>(List{})));
-    };
-
     template<typename List, std::size_t I>
     struct remove_impl {
         using type =
@@ -149,6 +143,12 @@ template<typename T>
 [[nodiscard]] constexpr auto posu::meta::find(list_type auto l) noexcept
 {
     return detail::find_impl<T>(l);
+}
+
+template<std::size_t I, typename T>
+[[nodiscard]] constexpr auto posu::meta::insert(list_type auto l) noexcept requires(I <= l.size())
+{
+    return concatenate(first<I>(l), push_front<T>(last<l.size() - I>(l)));
 }
 
 template<posu::meta::list_type TypeList, typename... Args>

--- a/posu/meta/ipp/ratio.ipp
+++ b/posu/meta/ipp/ratio.ipp
@@ -14,7 +14,7 @@ namespace posu::meta::detail {
             return make_ratio(num, den);
         }
         else {
-            constexpr auto pos = find_v<Den, at<Num, I>>;
+            constexpr auto pos = find<at<Num, I>>(Den{});
             if constexpr(pos < den.size()) {
                 return make_ratio(remove<Num, I>{}, remove<Den, pos>{});
             }

--- a/posu/meta/ipp/ratio.ipp
+++ b/posu/meta/ipp/ratio.ipp
@@ -51,25 +51,13 @@ namespace posu::meta::detail {
 
 } // namespace posu::meta::detail
 
-[[nodiscard]] constexpr bool
-posu::meta::detail::ratio_equal(ratio_type auto lhs, ratio_type auto rhs) noexcept
+[[nodiscard]] constexpr auto
+posu::meta::detail::ratio_multiply(ratio_type auto lhs, ratio_type auto rhs) noexcept
 {
-    return std::same_as<decltype(ratio_divide(lhs, rhs)), ratio<>>;
+    return detail::ratio_reduce(concatenate(lhs.num, rhs.num), concatenate(lhs.den, rhs.den));
 }
 
 [[nodiscard]] constexpr auto posu::meta::invert(ratio_type auto r) noexcept
 {
     return detail::make_ratio(r.den, r.num);
-}
-
-[[nodiscard]] constexpr auto
-posu::meta::ratio_multiply(ratio_type auto lhs, ratio_type auto rhs) noexcept
-{
-    return detail::ratio_reduce(concatenate(lhs.num, rhs.num), concatenate(lhs.den, rhs.den));
-}
-
-[[nodiscard]] constexpr auto
-posu::meta::ratio_divide(ratio_type auto num, ratio_type auto den) noexcept
-{
-    return ratio_multiply(num, invert(den));
 }

--- a/posu/meta/ipp/ratio.ipp
+++ b/posu/meta/ipp/ratio.ipp
@@ -1,74 +1,70 @@
 
-namespace posu::meta {
+namespace posu::meta::detail {
 
-    namespace detail {
+    template<list_type Num, list_type Den>
+    [[nodiscard]] constexpr auto make_ratio(Num /*unused*/, Den /*unused*/) noexcept
+    {
+        return ratio<Num, Den>{};
+    }
 
-        template<list_type Num, list_type Den>
-        [[nodiscard]] constexpr auto make_ratio(Num /*unused*/, Den /*unused*/) noexcept
-        {
-            return ratio<Num, Den>{};
+    template<std::size_t I, list_type Num, list_type Den>
+    [[nodiscard]] constexpr auto ratio_reduce_left_index(Num num, Den den) noexcept
+    {
+        if constexpr(num.empty() || den.empty()) {
+            return make_ratio(num, den);
         }
-
-        template<std::size_t I, list_type Num, list_type Den>
-        [[nodiscard]] constexpr auto ratio_reduce_left_index(Num num, Den den) noexcept
-        {
-            if constexpr(num.empty() || den.empty()) {
-                return make_ratio(num, den);
+        else {
+            constexpr auto pos = find_v<Den, at<Num, I>>;
+            if constexpr(pos < den.size()) {
+                return make_ratio(remove<Num, I>{}, remove<Den, pos>{});
             }
             else {
-                constexpr auto pos = find_v<Den, at<Num, I>>;
-                if constexpr(pos < den.size()) {
-                    return make_ratio(remove<Num, I>{}, remove<Den, pos>{});
-                }
-                else {
-                    return make_ratio(num, den);
-                }
+                return make_ratio(num, den);
             }
         }
+    }
 
-        template<typename Lhs, typename Rhs, std::size_t I>
-        using ratio_reduce_left_index_t = decltype(ratio_reduce_left_index<I>(Lhs{}, Rhs{}));
+    template<typename Lhs, typename Rhs, std::size_t I>
+    using ratio_reduce_left_index_t = decltype(ratio_reduce_left_index<I>(Lhs{}, Rhs{}));
 
-        template<typename Lhs, typename Rhs, std::size_t LhsSize = size_v<Lhs>, std::size_t I = 0>
-        struct ratio_reduce_impl;
+    template<typename Lhs, typename Rhs, std::size_t LhsSize = size_v<Lhs>, std::size_t I = 0>
+    struct ratio_reduce_impl;
 
-        template<typename Lhs, typename Rhs, std::size_t LhsSize, std::size_t I>
-            requires(I < LhsSize)
-        struct ratio_reduce_impl<Lhs, Rhs, LhsSize, I>
-            : private ratio_reduce_impl<Lhs, Rhs, LhsSize, I + 1> {
-        private:
-            using parent_type   = ratio_reduce_impl<Lhs, Rhs, LhsSize, I + 1>;
-            using parent_type_t = typename parent_type::type;
+    template<typename Lhs, typename Rhs, std::size_t LhsSize, std::size_t I>
+        requires(I < LhsSize)
+    struct ratio_reduce_impl<Lhs, Rhs, LhsSize, I>
+        : private ratio_reduce_impl<Lhs, Rhs, LhsSize, I + 1> {
+    private:
+        using parent_type   = ratio_reduce_impl<Lhs, Rhs, LhsSize, I + 1>;
+        using parent_type_t = typename parent_type::type;
 
-            using lhs = typename parent_type_t::num;
-            using rhs = typename parent_type_t::den;
+        using lhs = typename parent_type_t::num;
+        using rhs = typename parent_type_t::den;
 
-        public:
-            using type = ratio_reduce_left_index_t<lhs, rhs, I>;
-        };
+    public:
+        using type = ratio_reduce_left_index_t<lhs, rhs, I>;
+    };
 
-        template<typename Lhs, typename Rhs, std::size_t LhsSize, std::size_t I>
-            requires(I == LhsSize)
-        struct ratio_reduce_impl<Lhs, Rhs, LhsSize, I> {
-            using type = ratio<Lhs, Rhs>;
-        };
+    template<typename Lhs, typename Rhs, std::size_t LhsSize, std::size_t I>
+        requires(I == LhsSize)
+    struct ratio_reduce_impl<Lhs, Rhs, LhsSize, I> {
+        using type = ratio<Lhs, Rhs>;
+    };
 
-        template<typename Lhs, typename Rhs>
-        using ratio_reduce_impl_t = typename ratio_reduce_impl<Lhs, Rhs>::type;
+    template<typename Lhs, typename Rhs>
+    using ratio_reduce_impl_t = typename ratio_reduce_impl<Lhs, Rhs>::type;
 
-        template<
-            typename... NumLhsTypes,
-            typename... DenLhsTypes,
-            typename... NumRhsTypes,
-            typename... DenRhsTypes>
-        struct ratio_multiply_impl<
-            ratio<list<NumLhsTypes...>, list<DenLhsTypes...>>,
-            ratio<list<NumRhsTypes...>, list<DenRhsTypes...>>> {
-            using type = ratio_reduce_impl_t<
-                list<NumLhsTypes..., NumRhsTypes...>,
-                list<DenLhsTypes..., DenRhsTypes...>>;
-        };
+    template<
+        typename... NumLhsTypes,
+        typename... DenLhsTypes,
+        typename... NumRhsTypes,
+        typename... DenRhsTypes>
+    struct ratio_multiply_impl<
+        ratio<list<NumLhsTypes...>, list<DenLhsTypes...>>,
+        ratio<list<NumRhsTypes...>, list<DenRhsTypes...>>> {
+        using type = ratio_reduce_impl_t<
+            list<NumLhsTypes..., NumRhsTypes...>,
+            list<DenLhsTypes..., DenRhsTypes...>>;
+    };
 
-    } // namespace detail
-
-} // namespace posu::meta
+} // namespace posu::meta::detail

--- a/posu/meta/ipp/ratio.ipp
+++ b/posu/meta/ipp/ratio.ipp
@@ -34,12 +34,12 @@ namespace posu::meta::detail {
             return ratio_reduce_impl<I - 1>(num, den);
         }
         else {
-            using reduced = decltype(ratio_reduce_left_index<I>(num, den));
+            constexpr auto reduced = ratio_reduce_left_index<I>(num, den);
             if constexpr(I == 0) {
-                return make_ratio(numerator<reduced>{}, denominator<reduced>{});
+                return reduced;
             }
             else {
-                return ratio_reduce_impl<I - 1>(numerator<reduced>{}, denominator<reduced>{});
+                return ratio_reduce_impl<I - 1>(reduced.num, reduced.den);
             }
         }
     }

--- a/posu/meta/ipp/ratio.ipp
+++ b/posu/meta/ipp/ratio.ipp
@@ -27,7 +27,7 @@ namespace posu::meta::detail {
     template<typename Lhs, typename Rhs, std::size_t I>
     using ratio_reduce_left_index_t = decltype(ratio_reduce_left_index<I>(Lhs{}, Rhs{}));
 
-    template<typename Lhs, typename Rhs, std::size_t LhsSize = size_v<Lhs>, std::size_t I = 0>
+    template<typename Lhs, typename Rhs, std::size_t LhsSize = size(Lhs{}), std::size_t I = 0>
     struct ratio_reduce_impl;
 
     template<typename Lhs, typename Rhs, std::size_t LhsSize, std::size_t I>

--- a/posu/meta/ipp/ratio.ipp
+++ b/posu/meta/ipp/ratio.ipp
@@ -7,16 +7,16 @@ namespace posu::meta::detail {
         return ratio<Num, Den>{};
     }
 
-    template<std::size_t I, list_type Num, list_type Den>
-    [[nodiscard]] constexpr auto ratio_reduce_left_index(Num num, Den den) noexcept
+    template<std::size_t I, list_type Num>
+    [[nodiscard]] constexpr auto ratio_reduce_left_index(Num num, list_type auto den) noexcept
     {
         if constexpr(num.empty() || den.empty()) {
             return make_ratio(num, den);
         }
         else {
-            constexpr auto pos = find<at<Num, I>>(Den{});
+            constexpr auto pos = find<at<Num, I>>(den);
             if constexpr(pos < den.size()) {
-                return make_ratio(remove<I>(Num{}), remove<pos>(Den{}));
+                return make_ratio(remove<I>(num), remove<pos>(den));
             }
             else {
                 return make_ratio(num, den);

--- a/posu/meta/ipp/ratio.ipp
+++ b/posu/meta/ipp/ratio.ipp
@@ -68,3 +68,10 @@ namespace posu::meta::detail {
     };
 
 } // namespace posu::meta::detail
+
+template<typename Lhs, typename Rhs>
+[[nodiscard]] constexpr bool
+posu::meta::detail::ratio_equal(Lhs /*unused*/, Rhs /*unused*/) noexcept
+{
+    return std::same_as<ratio_divide<Lhs, Rhs>, ratio<>>;
+}

--- a/posu/meta/ipp/ratio.ipp
+++ b/posu/meta/ipp/ratio.ipp
@@ -16,7 +16,7 @@ namespace posu::meta::detail {
         else {
             constexpr auto pos = find<at<Num, I>>(Den{});
             if constexpr(pos < den.size()) {
-                return make_ratio(remove<Num, I>{}, remove<Den, pos>{});
+                return make_ratio(remove<I>(Num{}), remove<pos>(Den{}));
             }
             else {
                 return make_ratio(num, den);

--- a/posu/meta/ipp/ratio.ipp
+++ b/posu/meta/ipp/ratio.ipp
@@ -69,7 +69,7 @@ namespace posu::meta::detail {
 
 } // namespace posu::meta::detail
 
-template<typename Lhs, typename Rhs>
+template<posu::meta::ratio_type Lhs, posu::meta::ratio_type Rhs>
 [[nodiscard]] constexpr bool
 posu::meta::detail::ratio_equal(Lhs /*unused*/, Rhs /*unused*/) noexcept
 {

--- a/posu/meta/ipp/ratio.ipp
+++ b/posu/meta/ipp/ratio.ipp
@@ -70,3 +70,8 @@ posu::meta::detail::ratio_equal(Lhs /*unused*/, Rhs /*unused*/) noexcept
 {
     return std::same_as<ratio_divide<Lhs, Rhs>, ratio<>>;
 }
+
+[[nodiscard]] constexpr auto posu::meta::invert(ratio_type auto r) noexcept
+{
+    return detail::make_ratio(r.den, r.num);
+}

--- a/posu/meta/ipp/ratio.ipp
+++ b/posu/meta/ipp/ratio.ipp
@@ -49,29 +49,27 @@ namespace posu::meta::detail {
         return ratio_reduce_impl<num.size()>(num, den);
     }
 
-    template<
-        typename... NumLhsTypes,
-        typename... DenLhsTypes,
-        typename... NumRhsTypes,
-        typename... DenRhsTypes>
-    struct ratio_multiply_impl<
-        ratio<list<NumLhsTypes...>, list<DenLhsTypes...>>,
-        ratio<list<NumRhsTypes...>, list<DenRhsTypes...>>> {
-        using type = decltype(ratio_reduce(
-            list<NumLhsTypes..., NumRhsTypes...>{},
-            list<DenLhsTypes..., DenRhsTypes...>{}));
-    };
-
 } // namespace posu::meta::detail
 
-template<posu::meta::ratio_type Lhs, posu::meta::ratio_type Rhs>
 [[nodiscard]] constexpr bool
-posu::meta::detail::ratio_equal(Lhs /*unused*/, Rhs /*unused*/) noexcept
+posu::meta::detail::ratio_equal(ratio_type auto lhs, ratio_type auto rhs) noexcept
 {
-    return std::same_as<ratio_divide<Lhs, Rhs>, ratio<>>;
+    return std::same_as<decltype(ratio_divide(lhs, rhs)), ratio<>>;
 }
 
 [[nodiscard]] constexpr auto posu::meta::invert(ratio_type auto r) noexcept
 {
     return detail::make_ratio(r.den, r.num);
+}
+
+[[nodiscard]] constexpr auto
+posu::meta::ratio_multiply(ratio_type auto lhs, ratio_type auto rhs) noexcept
+{
+    return detail::ratio_reduce(concatenate(lhs.num, rhs.num), concatenate(lhs.den, rhs.den));
+}
+
+[[nodiscard]] constexpr auto
+posu::meta::ratio_divide(ratio_type auto num, ratio_type auto den) noexcept
+{
+    return ratio_multiply(num, invert(den));
 }

--- a/posu/meta/ipp/ratio.ipp
+++ b/posu/meta/ipp/ratio.ipp
@@ -24,9 +24,6 @@ namespace posu::meta::detail {
         }
     }
 
-    template<typename Lhs, typename Rhs, std::size_t I>
-    using ratio_reduce_left_index_t = decltype(ratio_reduce_left_index<I>(Lhs{}, Rhs{}));
-
     template<typename Lhs, typename Rhs, std::size_t LhsSize = size(Lhs{}), std::size_t I = 0>
     struct ratio_reduce_impl;
 
@@ -38,11 +35,8 @@ namespace posu::meta::detail {
         using parent_type   = ratio_reduce_impl<Lhs, Rhs, LhsSize, I + 1>;
         using parent_type_t = typename parent_type::type;
 
-        using lhs = typename parent_type_t::num;
-        using rhs = typename parent_type_t::den;
-
     public:
-        using type = ratio_reduce_left_index_t<lhs, rhs, I>;
+        using type = decltype(ratio_reduce_left_index<I>(parent_type_t::num, parent_type_t::den));
     };
 
     template<typename Lhs, typename Rhs, std::size_t LhsSize, std::size_t I>

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -135,14 +135,6 @@ namespace posu::meta {
     template<typename T>
     concept list_type = detail::is_list<T>::value;
 
-    namespace detail
-    {
-
-        template<typename List, std::size_t I>
-        struct remove_impl;
-
-    } // namespace detail
-
     /**
      * @brief Concatenate multiple `list`s into a single `list`.
      *
@@ -325,14 +317,37 @@ namespace posu::meta {
     [[nodiscard]] constexpr auto insert(list_type auto l) noexcept requires(I <= l.size());
 
     /**
-     * @brief Remove the type at the givien position in the type list.
+     * @brief Remove the types at the given positions in the type list.
      *
-     * @tparam List The list to remove a type from.
-     * @tparam I    The index of the type to remove.
+     * @tparam I he indices of the elements to remove.
+     *
+     * @param l The list to remove elements from.
+     * @param i The indices of the elements to remove.
+     *
+     * @return Returns a list with the elemenst at the given indices removed.
      */
-    template<list_type List, std::size_t I>
-        requires(I < List::size())
-    using remove = typename detail::remove_impl<List, I>::type;
+    template<std::size_t... I>
+    [[nodiscard]] constexpr auto remove(list_type auto l, std::index_sequence<I...> i = {}) noexcept
+        requires((I < l.size()) && ...);
+
+    /**
+     * @brief Remove a range of elements from the given type list.
+     *
+     * @tparam Begin The starting index of the range to remove.
+     * @tparam End   The one-past-the-ending index of the range to remove.
+     *
+     * @param l     The list to remove a range from.
+     * @param begin The starting index of the range to remove.
+     * @param end   The one-past-the-ending index of the range to remove.
+     *
+     * @return Returns a list with the given range removed.
+     */
+    template<std::size_t Begin, std::size_t End>
+    [[nodiscard]] constexpr auto remove_range(
+        list_type auto                             l,
+        std::integral_constant<std::size_t, Begin> begin = {},
+        std::integral_constant<std::size_t, End>   end   = {}) noexcept
+        requires((Begin <= End) && (End <= l.size()));
 
     /**
      * @brief Check whether or not the given type exists in the given type list.

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -138,9 +138,6 @@ namespace posu::meta {
     namespace detail
     {
 
-        template<typename... Lists>
-        struct concatenate_impl;
-
         template<typename List, typename T>
         struct prepend_impl;
 
@@ -192,10 +189,9 @@ namespace posu::meta {
     /**
      * @brief Concatenate multiple `list`s into a single `list`.
      *
-     * @tparam Lists The lists to concatenate together.
+     * @param part The lists to concatenate together.
      */
-    template<list_type... Lists>
-    using concatenate = typename detail::concatenate_impl<Lists...>::type;
+    [[nodiscard]] constexpr auto concatenate(list_type auto... part) noexcept;
 
     /**
      * @brief Prepend a type to a `list`.

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -249,9 +249,8 @@ namespace posu::meta {
      * @tparam List The list get the first types of.
      * @tparam I    The number of elements to get.
      */
-    template<list_type List, std::size_t I = 0>
-        requires(I <= List::size())
-    using first = decltype(take(List{}, std::make_index_sequence<I>{}));
+    template<std::size_t N, typename... T>
+    [[nodiscard]] constexpr auto first(list<T...> l) noexcept requires(N <= l.size());
 
     /**
      * @brief Get the last `I` elements of the given list as a `list`.
@@ -259,9 +258,8 @@ namespace posu::meta {
      * @tparam List The list get the last types of.
      * @tparam I    The number of elements to get.
      */
-    template<list_type List, std::size_t I = 0>
-        requires(I <= List::size())
-    using last = decltype(take_range<List::size() - I, List::size()>(List{}));
+    template<std::size_t N>
+    [[nodiscard]] constexpr auto last(list_type auto l) noexcept requires(N <= l.size());
 
     /**
      * @brief Get the number of elements in the given type list.

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -305,6 +305,8 @@ namespace posu::meta {
      *
      * @tparam T The type to find in the given list.
      *
+     * @param l The list to search for the given type in.
+     *
      * @return Returns the index of the given type in the given list, or `l.size()` if not found.
      */
     template<typename T>

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -278,10 +278,20 @@ namespace posu::meta {
         requires(I < typename List::size())
     using at = typename List::template at<I>;
 
+    /**
+     * @brief Get the first type in the type list.
+     *
+     * @tparam List The list to get the first element of.
+     */
     template<list_type List>
         requires(!typename List::empty())
     using front = at<List, 0>;
 
+    /**
+     * @brief Get the last type in the type list.
+     *
+     * @tparam List The list to get the last element of.
+     */
     template<list_type List>
         requires(!typename List::empty())
     using back = at<List, typename List::size() - 1>;

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -72,6 +72,20 @@ namespace posu::meta {
         [[nodiscard]] static constexpr auto
         make_variant(Args&&... args) noexcept(std::is_nothrow_constructible_v<variant, Args...>)
             -> variant;
+
+        /**
+         * @brief Equality comparison operator.
+         *
+         * @tparam T The types in the list to compare against.
+         *
+         * @param lhs The left-hand-side comparison operand.
+         * @param rhs The right-hand-side comparison operand.
+         */
+        template<typename... T>
+        [[nodiscard]] friend constexpr bool operator==(list /*lhs*/, list<T...> /*rhs*/) noexcept
+        {
+            return std::same_as<list, list<T...>>;
+        }
     };
 
 } // namespace posu::meta

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -138,12 +138,6 @@ namespace posu::meta {
     namespace detail
     {
 
-        template<typename List>
-        struct pop_front_impl;
-
-        template<typename List>
-        struct pop_back_impl;
-
         template<typename List, typename IndexSequence>
         struct take_items;
 
@@ -216,18 +210,16 @@ namespace posu::meta {
     /**
      * @brief Remove the first type in a `list`.
      *
-     * @tparam List The list to pop a type from.
+     * @param l The list to pop a type from.
      */
-    template<list_type List>
-    using pop_front = typename detail::pop_front_impl<List>::type;
+    [[nodiscard]] constexpr auto pop_front(list_type auto l) noexcept;
 
     /**
      * @brief Remove the last type in a `list`.
      *
-     * @tparam List The list to pop a type from.
+     * @param l The list to pop a type from.
      */
-    template<list_type List>
-    using pop_back = typename detail::pop_back_impl<List>::type;
+    [[nodiscard]] constexpr auto pop_back(list_type auto l) noexcept;
 
     /**
      * @brief Get the first `I` elements of the given list as a `list`.

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -15,19 +15,20 @@ namespace posu::meta {
     template<typename... Types>
     struct list {
     public:
+        using size_type  = decltype(sizeof...(Types));    //!< Unsigned number-of-elements type.
+        using ssize_type = std::make_signed_t<size_type>; //!< Signed number-of-elements type.
+
         /**
-         * @brief The number of elements in the list.
+         * @brief Query the number of elements in the list.
+         *
+         * @return Returns the requested list size information.
          *
          * @{
          */
-        using size  = std::integral_constant<std::size_t, sizeof...(Types)>;
-        using ssize = std::integral_constant<std::make_signed_t<std::size_t>, sizeof...(Types)>;
+        [[nodiscard]] static constexpr auto size() noexcept { return sizeof...(Types); }
+        [[nodiscard]] static constexpr auto ssize() noexcept { return ssize_type{size()}; }
+        [[nodiscard]] static constexpr bool empty() noexcept { return size() == 0; }
         //! @}
-
-        /**
-         * @brief Whether the list is empty or not.
-         */
-        using empty = std::bool_constant<size::value == 0>;
 
         /**
          * @brief The tuple type that has the listed types as its elements.
@@ -225,7 +226,7 @@ namespace posu::meta {
      * @tparam I    The number of elements to get.
      */
     template<list_type List, std::size_t I = 0>
-        requires(I <= typename List::size())
+        requires(I <= List::size())
     using first = typename detail::first_impl<List, I>::type;
 
     /**
@@ -235,7 +236,7 @@ namespace posu::meta {
      * @tparam I    The number of elements to get.
      */
     template<list_type List, std::size_t I = 0>
-        requires(I <= typename List::size())
+        requires(I <= List::size())
     using last = typename detail::last_impl<List, I>::type;
 
     /**
@@ -246,9 +247,9 @@ namespace posu::meta {
      * @{
      */
     template<list_type List>
-    using size = typename List::size;
+    using size = std::integral_constant<typename List::size_type, List::size()>;
     template<list_type List>
-    using ssize = typename List::ssize;
+    using ssize = std::integral_constant<typename List::ssize_type, List::ssize()>;
     template<typename List>
     inline constexpr auto size_v = size<List>::value;
     template<typename List>
@@ -263,9 +264,9 @@ namespace posu::meta {
      * @{
      */
     template<list_type List>
-    using empty = typename List::empty;
+    using empty = std::bool_constant<List::empty()>;
     template<typename List>
-    inline constexpr auto empty_v = empty<List>::value;
+    inline constexpr auto empty_v = List::empty();
     //! @}
 
     /**
@@ -275,7 +276,7 @@ namespace posu::meta {
      * @tparam I    The index of the list element to get.
      */
     template<list_type List, std::size_t I>
-        requires(I < typename List::size())
+        requires(I < List::size())
     using at = typename List::template at<I>;
 
     /**
@@ -284,7 +285,7 @@ namespace posu::meta {
      * @tparam List The list to get the first element of.
      */
     template<list_type List>
-        requires(!typename List::empty())
+        requires(!List::empty())
     using front = at<List, 0>;
 
     /**
@@ -293,8 +294,8 @@ namespace posu::meta {
      * @tparam List The list to get the last element of.
      */
     template<list_type List>
-        requires(!typename List::empty())
-    using back = at<List, typename List::size() - 1>;
+        requires(!List::empty())
+    using back = at<List, List::size() - 1>;
 
     /**
      * @brief Find the index of the first ocurrence of the given type.
@@ -318,7 +319,7 @@ namespace posu::meta {
      * @tparam T    The type to insert.
      */
     template<list_type List, std::size_t I, typename T>
-        requires(I <= typename List::size())
+        requires(I <= List::size())
     using insert = typename detail::insert_impl<List, I, T>::type;
 
     /**
@@ -328,7 +329,7 @@ namespace posu::meta {
      * @tparam I    The index of the type to remove.
      */
     template<list_type List, std::size_t I>
-        requires(I < typename List::size())
+        requires(I < List::size())
     using remove = typename detail::remove_impl<List, I>::type;
 
     /**

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -167,6 +167,8 @@ namespace posu::meta {
      * @brief Concatenate multiple `list`s into a single `list`.
      *
      * @param part The lists to concatenate together.
+     *
+     * @return Returns the resulting concatenated list.
      */
     [[nodiscard]] constexpr auto concatenate(list_type auto... part) noexcept;
 
@@ -200,6 +202,8 @@ namespace posu::meta {
      * @brief Remove the first type in a `list`.
      *
      * @param l The list to pop a type from.
+     *
+     * @return Returns the given list without the first element.
      */
     [[nodiscard]] constexpr auto pop_front(list_type auto l) noexcept;
 
@@ -207,6 +211,8 @@ namespace posu::meta {
      * @brief Remove the last type in a `list`.
      *
      * @param l The list to pop a type from.
+     *
+     * @return Returns the given list without the last element.
      */
     [[nodiscard]] constexpr auto pop_back(list_type auto l) noexcept;
 

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -138,12 +138,6 @@ namespace posu::meta {
     namespace detail
     {
 
-        template<typename List, typename T>
-        struct prepend_impl;
-
-        template<typename List, typename T>
-        struct append_impl;
-
         template<typename List>
         struct pop_front_impl;
 
@@ -196,22 +190,28 @@ namespace posu::meta {
     /**
      * @brief Prepend a type to a `list`.
      *
-     * @tparam List The list to prepend a type to.
-     * @tparam Type The type to prepend to the list. If `Type` is an single-element list
-     *              `list<T>`, prepends `T` instead.
+     * @param T      The type to prepend to the list.
+     * @param Listed The types already in the list to push into.
+     *
+     * @param l The list to push a new type into.
+     *
+     * @return Returns a list with the new type added to the front.
      */
-    template<list_type List, typename Type>
-    using push_front = typename detail::prepend_impl<List, Type>::type;
+    template<typename T, typename... Listed>
+    [[nodiscard]] constexpr auto push_front(list<Listed...> l) noexcept;
 
     /**
      * @brief Append a type to a `list`.
      *
-     * @tparam List The list to append a type to.
-     * @tparam Type The type to append to the list. If `Type` is an single-element list
-     *              `list<T>`, appends `T` instead.
+     * @param T      The type to prepend to the list.
+     * @param Listed The types already in the list to push into.
+     *
+     * @param l The list to push a new type into.
+     *
+     * @return Returns a list with the new type added to the back.
      */
-    template<list_type List, typename Type>
-    using push_back = typename detail::append_impl<List, Type>::type;
+    template<typename T, typename... Listed>
+    [[nodiscard]] constexpr auto push_back(list<Listed...> l) noexcept;
 
     /**
      * @brief Remove the first type in a `list`.

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -262,34 +262,32 @@ namespace posu::meta {
     [[nodiscard]] constexpr auto last(list_type auto l) noexcept requires(N <= l.size());
 
     /**
-     * @brief Get the number of elements in the given type list.
+     * @brief Obtain the number of elements in the given list as an unsigned integer.
      *
-     * @tparam List The list to get an element of.
+     * @param l The list to obtain the size of.
      *
-     * @{
+     * @return Returns the size of the given list.
      */
-    template<list_type List>
-    using size = std::integral_constant<typename List::size_type, List::size()>;
-    template<list_type List>
-    using ssize = std::integral_constant<typename List::ssize_type, List::ssize()>;
-    template<typename List>
-    inline constexpr auto size_v = size<List>::value;
-    template<typename List>
-    inline constexpr auto ssize_v = ssize<List>::value;
-    //! @}
+    [[nodiscard]] constexpr auto size(list_type auto l) noexcept { return l.size(); }
 
     /**
-     * @brief Check whether the given type list is empty or not.
+     * @brief Obtain the number of elements in the given list as a signed integer.
      *
-     * @tparam List The list to check the emptiness of.
+     * @param l The list to obtain the size of.
      *
-     * @{
+     * @return Returns the size of the given list.
      */
-    template<list_type List>
-    using empty = std::bool_constant<List::empty()>;
-    template<typename List>
-    inline constexpr auto empty_v = List::empty();
-    //! @}
+    [[nodiscard]] constexpr auto ssize(list_type auto l) noexcept { return l.ssize(); }
+
+    /**
+     * @brief Check whether the given list has elements or not.
+     *
+     * @param l The list to check the emptiness ofl.
+     *
+     * @retval true  The given list has no elements.
+     * @retval false The given list has elements.
+     */
+    [[nodiscard]] constexpr bool empty(list_type auto l) noexcept { return l.empty(); }
 
     /**
      * @brief Get the type at the given index in the type list.

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -352,17 +352,15 @@ namespace posu::meta {
     /**
      * @brief Check whether or not the given type exists in the given type list.
      *
-     * @tparam List The list to check for the given type in.
-     * @tparam T    The type to check the existence of in the given list.
+     * @tparam T The type to check the existence of in the given list.
      *
-     * @{
+     * @param l The list to check for the given type in.
+     *
+     * @retval true  The given list contains the given type.
+     * @retval false The given list does not contain the given type.
      */
-    template<typename List, typename T>
-    struct contains : public std::bool_constant<std::less{}(find<T>(List{}), List::size::value)> {
-    };
-    template<typename List, typename T>
-    inline constexpr auto contains_v = contains<List, T>::value;
-    //! @}
+    template<typename T>
+    [[nodiscard]] constexpr bool contains(list_type auto l) noexcept;
 
     /**
      * @brief Transform a `list` to its corresponding tuple type.

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -220,6 +220,8 @@ namespace posu::meta {
      * @tparam Begin The starting index of the sub-list.
      * @tparam End   The one-past-the-ending index of the sub-list.
      *
+     * @param l The list to take a sub-list of.
+     *
      * @return Returns the sub-list.
      */
     template<std::size_t Begin, std::size_t End>

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -138,12 +138,6 @@ namespace posu::meta {
     namespace detail
     {
 
-        template<typename List, typename T, std::size_t I = 0>
-        [[nodiscard]] constexpr auto find_impl_fn() noexcept->std::size_t;
-
-        template<typename List, typename T>
-        using find_impl = std::integral_constant<std::size_t, find_impl_fn<List, T>()>;
-
         template<typename List, std::size_t I, typename T>
         struct insert_impl;
 
@@ -309,16 +303,12 @@ namespace posu::meta {
     /**
      * @brief Find the index of the first ocurrence of the given type.
      *
-     * @tparam List The list to find the given type in.
-     * @tparam T    The type to find in the given list.
+     * @tparam T The type to find in the given list.
      *
-     * @{
+     * @return Returns the index of the given type in the given list, or `l.size()` if not found.
      */
-    template<list_type List, typename T>
-    using find = typename detail::find_impl<List, T>::type;
-    template<typename List, typename T>
-    inline constexpr auto find_v = find<List, T>::value;
-    //! @}
+    template<typename T>
+    [[nodiscard]] constexpr auto find(list_type auto l) noexcept;
 
     /**
      * @brief Insert the given type into the given type list at the given index.
@@ -350,8 +340,7 @@ namespace posu::meta {
      * @{
      */
     template<typename List, typename T>
-    struct contains
-        : public std::bool_constant<std::less{}(find<List, T>::value, List::size::value)> {
+    struct contains : public std::bool_constant<std::less{}(find<T>(List{}), List::size::value)> {
     };
     template<typename List, typename T>
     inline constexpr auto contains_v = contains<List, T>::value;

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -166,27 +166,17 @@ namespace std {
 
 namespace posu::meta {
 
-    /**
-     * @brief Traits template to detect whether a type specializes `list` or not.
-     * @{
-     */
-    //! @tparam T The type to check.
-    template<typename T>
-    struct is_list : std::false_type {
-    };
-    //! @tparam Types The types in the type list.
-    template<typename... Types>
-    struct is_list<list<Types...>> : std::true_type {
-    };
-    //! @}
+    namespace detail {
 
-    /**
-     * @brief Traits constant indicating whether or not a type specializes `list`.
-     *
-     * @tparam T The type to check.
-     */
-    template<typename T>
-    inline constexpr bool is_list_v = is_list<T>::value;
+        template<typename T>
+        struct is_list : std::false_type {
+        };
+
+        template<typename... Types>
+        struct is_list<list<Types...>> : std::true_type {
+        };
+
+    } // namespace detail
 
     /**
      * @brief T type that instantiates `list`.
@@ -194,7 +184,7 @@ namespace posu::meta {
      * @tparam T The type to check against this concept.
      */
     template<typename T>
-    concept list_type = is_list_v<T>;
+    concept list_type = detail::is_list<T>::value;
 
     namespace detail
     {
@@ -255,8 +245,7 @@ namespace posu::meta {
      *
      * @tparam Lists The lists to concatenate together.
      */
-    template<typename... Lists>
-        requires(is_list_v<Lists>&&...)
+    template<list_type... Lists>
     using concatenate = typename detail::concatenate_impl<Lists...>::type;
 
     /**
@@ -266,8 +255,7 @@ namespace posu::meta {
      * @tparam Type The type to prepend to the list. If `Type` is an single-element list
      *              `list<T>`, prepends `T` instead.
      */
-    template<typename List, typename Type>
-        requires(is_list_v<List>)
+    template<list_type List, typename Type>
     using push_front = typename detail::prepend_impl<List, Type>::type;
 
     /**
@@ -277,8 +265,7 @@ namespace posu::meta {
      * @tparam Type The type to append to the list. If `Type` is an single-element list
      *              `list<T>`, appends `T` instead.
      */
-    template<typename List, typename Type>
-        requires(is_list_v<List>)
+    template<list_type List, typename Type>
     using push_back = typename detail::append_impl<List, Type>::type;
 
     /**
@@ -286,8 +273,7 @@ namespace posu::meta {
      *
      * @tparam List The list to pop a type from.
      */
-    template<typename List>
-        requires(is_list_v<List>)
+    template<list_type List>
     using pop_front = typename detail::pop_front_impl<List>::type;
 
     /**
@@ -295,8 +281,7 @@ namespace posu::meta {
      *
      * @tparam List The list to pop a type from.
      */
-    template<typename List>
-        requires(is_list_v<List>)
+    template<list_type List>
     using pop_back = typename detail::pop_back_impl<List>::type;
 
     /**
@@ -305,8 +290,8 @@ namespace posu::meta {
      * @tparam List The list get the first types of.
      * @tparam I    The number of elements to get.
      */
-    template<typename List, std::size_t I = 0>
-        requires(is_list_v<List> && (I <= typename List::size()))
+    template<list_type List, std::size_t I = 0>
+        requires(I <= typename List::size())
     using first = typename detail::first_impl<List, I>::type;
 
     /**
@@ -315,8 +300,8 @@ namespace posu::meta {
      * @tparam List The list get the last types of.
      * @tparam I    The number of elements to get.
      */
-    template<typename List, std::size_t I = 0>
-        requires(is_list_v<List> && (I <= typename List::size()))
+    template<list_type List, std::size_t I = 0>
+        requires(I <= typename List::size())
     using last = typename detail::last_impl<List, I>::type;
 
     /**
@@ -326,11 +311,9 @@ namespace posu::meta {
      *
      * @{
      */
-    template<typename List>
-        requires(is_list_v<List>)
+    template<list_type List>
     using size = typename List::size;
-    template<typename List>
-        requires(is_list_v<List>)
+    template<list_type List>
     using ssize = typename List::ssize;
     template<typename List>
     inline constexpr auto size_v = size<List>::value;
@@ -345,8 +328,7 @@ namespace posu::meta {
      *
      * @{
      */
-    template<typename List>
-        requires(is_list_v<List>)
+    template<list_type List>
     using empty = typename List::empty;
     template<typename List>
     inline constexpr auto empty_v = empty<List>::value;
@@ -358,8 +340,8 @@ namespace posu::meta {
      * @tparam List The list to get an element of.
      * @tparam I    The index of the list element to get.
      */
-    template<typename List, std::size_t I>
-        requires(is_list_v<List> && (I < typename List::size()))
+    template<list_type List, std::size_t I>
+        requires(I < typename List::size())
     using at = typename List::template at<I>;
 
     /**
@@ -370,8 +352,7 @@ namespace posu::meta {
      *
      * @{
      */
-    template<typename List, typename T>
-        requires(is_list_v<List>)
+    template<list_type List, typename T>
     using find = typename detail::find_impl<List, T>::type;
     template<typename List, typename T>
     inline constexpr auto find_v = find<List, T>::value;
@@ -384,8 +365,8 @@ namespace posu::meta {
      * @tparam I    The index to insert a new type at.
      * @tparam T    The type to insert.
      */
-    template<typename List, std::size_t I, typename T>
-        requires(is_list_v<List> && (I <= typename List::size()))
+    template<list_type List, std::size_t I, typename T>
+        requires(I <= typename List::size())
     using insert = typename detail::insert_impl<List, I, T>::type;
 
     /**
@@ -394,8 +375,8 @@ namespace posu::meta {
      * @tparam List The list to remove a type from.
      * @tparam I    The index of the type to remove.
      */
-    template<typename List, std::size_t I>
-        requires(is_list_v<List> && (I < typename List::size()))
+    template<list_type List, std::size_t I>
+        requires(I < typename List::size())
     using remove = typename detail::remove_impl<List, I>::type;
 
     /**
@@ -421,8 +402,7 @@ namespace posu::meta {
      *
      * @{
      */
-    template<typename TypeList>
-        requires is_list_v<TypeList>
+    template<list_type TypeList>
     struct tuple_from {
         using type = typename TypeList::tuple;
     };
@@ -437,8 +417,7 @@ namespace posu::meta {
      *
      * @{
      */
-    template<typename TypeList>
-        requires is_list_v<TypeList>
+    template<list_type TypeList>
     struct variant_from {
         using type = typename TypeList::variant;
     };
@@ -455,8 +434,7 @@ namespace posu::meta {
      * @param args The arguments to forward to the tuple constructor.
      * @return Returns the constructed tuple.
      */
-    template<typename TypeList, typename... Args>
-        requires is_list_v<TypeList>
+    template<list_type TypeList, typename... Args>
     [[nodiscard]] constexpr auto make_tuple_from(TypeList list, Args&&... args) noexcept(
         std::is_nothrow_constructible_v<tuple_from_t<TypeList>>) -> tuple_from_t<TypeList>;
 
@@ -469,8 +447,7 @@ namespace posu::meta {
      * @param args The arguments to forward to the variant constructor.
      * @return Returns the constructed variant.
      */
-    template<typename TypeList, typename... Args>
-        requires is_list_v<TypeList>
+    template<list_type TypeList, typename... Args>
     [[nodiscard]] constexpr auto make_variant_from(TypeList list, Args&&... args) noexcept(
         std::is_nothrow_constructible_v<variant_from_t<TypeList>>) -> variant_from_t<TypeList>;
 

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -363,60 +363,50 @@ namespace posu::meta {
     [[nodiscard]] constexpr bool contains(list_type auto l) noexcept;
 
     /**
-     * @brief Transform a `list` to its corresponding tuple type.
+     * @brief Obtain a tuple type that has members of the types in the given type list.
      *
-     * @tparam TypeList The list to transform.
-     *
-     * @{
+     * @tparam TypeList The list to obtain the corresponding tuple type of.
      */
-    template<list_type TypeList>
-    struct tuple_from {
-        using type = typename TypeList::tuple;
-    };
     template<typename TypeList>
-    using tuple_from_t = typename tuple_from<TypeList>::type;
-    //! @}
+    using tuple_from = typename TypeList::tuple;
 
     /**
-     * @brief Transform a `list` to its corresponding variant type.
+     * @brief Obtain a variant type that can hold all the types in the given type list.
      *
-     * @tparam TypeList The list to transform.
-     *
-     * @{
+     * @tparam TypeList The list to obtain the corresponding variant type of.
      */
     template<list_type TypeList>
-    struct variant_from {
-        using type = typename TypeList::variant;
-    };
-    template<typename TypeList>
-    using variant_from_t = typename variant_from<TypeList>::type;
-    //! @}
+    using variant_from = typename TypeList::variant;
 
     /**
      * @brief Construct a tuple from its corresponding `list`.
      *
      * @tparam TypeList The list to construct a tuple from.
-     * @tparam Args The types of arguments to forward to the tuple constructor.
+     * @tparam Args     The types of arguments to forward to the tuple constructor.
+     *
      * @param list The type list object.
      * @param args The arguments to forward to the tuple constructor.
+     *
      * @return Returns the constructed tuple.
      */
     template<list_type TypeList, typename... Args>
     [[nodiscard]] constexpr auto make_tuple_from(TypeList list, Args&&... args) noexcept(
-        std::is_nothrow_constructible_v<tuple_from_t<TypeList>>) -> tuple_from_t<TypeList>;
+        std::is_nothrow_constructible_v<tuple_from<TypeList>, Args...>) -> tuple_from<TypeList>;
 
     /**
      * @brief Construct a variant from its corresponding `list`.
      *
      * @tparam TypeList The list to construct a variant from.
-     * @tparam Args The types of arguments to forward to the variant constructor.
+     * @tparam Args     The types of arguments to forward to the variant constructor.
+     *
      * @param list The type list object.
      * @param args The arguments to forward to the variant constructor.
+     *
      * @return Returns the constructed variant.
      */
     template<list_type TypeList, typename... Args>
     [[nodiscard]] constexpr auto make_variant_from(TypeList list, Args&&... args) noexcept(
-        std::is_nothrow_constructible_v<variant_from_t<TypeList>>) -> variant_from_t<TypeList>;
+        std::is_nothrow_constructible_v<variant_from<TypeList>, Args...>) -> variant_from<TypeList>;
 
 } // namespace posu::meta
 

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -188,7 +188,16 @@ namespace posu::meta {
     template<typename T>
     inline constexpr bool is_list_v = is_list<T>::value;
 
-    namespace detail {
+    /**
+     * @brief T type that instantiates `list`.
+     *
+     * @tparam T The type to check against this concept.
+     */
+    template<typename T>
+    concept list_type = is_list_v<T>;
+
+    namespace detail
+    {
 
         template<typename... Lists>
         struct concatenate_impl;
@@ -228,7 +237,7 @@ namespace posu::meta {
             add_offset_t<std::tuple_size_v<List> - I, std::make_index_sequence<I>>>;
 
         template<typename List, typename T, std::size_t I = 0>
-        [[nodiscard]] constexpr auto find_impl_fn() noexcept -> std::size_t;
+        [[nodiscard]] constexpr auto find_impl_fn() noexcept->std::size_t;
 
         template<typename List, typename T>
         using find_impl = std::integral_constant<std::size_t, find_impl_fn<List, T>()>;

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -138,9 +138,6 @@ namespace posu::meta {
     namespace detail
     {
 
-        template<typename List, std::size_t I, typename T>
-        struct insert_impl;
-
         template<typename List, std::size_t I>
         struct remove_impl;
 
@@ -317,13 +314,15 @@ namespace posu::meta {
     /**
      * @brief Insert the given type into the given type list at the given index.
      *
-     * @tparam List The list to insert a type into.
      * @tparam I    The index to insert a new type at.
      * @tparam T    The type to insert.
+     *
+     * @param l The list to insert into.
+     *
+     * @return Returns the list with the newly-inserted element.
      */
-    template<list_type List, std::size_t I, typename T>
-        requires(I <= List::size())
-    using insert = typename detail::insert_impl<List, I, T>::type;
+    template<std::size_t I, typename T>
+    [[nodiscard]] constexpr auto insert(list_type auto l) noexcept requires(I <= l.size());
 
     /**
      * @brief Remove the type at the givien position in the type list.

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -138,17 +138,6 @@ namespace posu::meta {
     namespace detail
     {
 
-        template<std::size_t Offset, typename IndexSequence>
-        struct add_offset;
-
-        template<std::size_t Offset, std::size_t... Values>
-        struct add_offset<Offset, std::index_sequence<Values...>> {
-            using type = std::index_sequence<(Values + Offset)...>;
-        };
-
-        template<std::size_t Offset, typename IndexSequence>
-        using add_offset_t = typename add_offset<Offset, IndexSequence>::type;
-
         template<typename List, typename T, std::size_t I = 0>
         [[nodiscard]] constexpr auto find_impl_fn() noexcept->std::size_t;
 

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -16,14 +16,6 @@ namespace posu::meta {
     struct list {
     public:
         /**
-         * @brief The type at the given index in the range.
-         *
-         * @tparam I The index of the type to access.
-         */
-        template<std::size_t I>
-        using at = std::tuple_element_t<I, std::tuple<Types...>>;
-
-        /**
          * @brief The number of elements in the list.
          *
          * @{
@@ -38,16 +30,6 @@ namespace posu::meta {
         using empty = std::bool_constant<size::value == 0>;
 
         /**
-         * @brief The first type in the list.
-         */
-        using front = at<0>;
-
-        /**
-         * @brief The last type in the list.
-         */
-        using back = at<size::value - 1>;
-
-        /**
          * @brief The tuple type that has the listed types as its elements.
          */
         using tuple = std::tuple<Types...>;
@@ -58,61 +40,13 @@ namespace posu::meta {
         using variant = std::variant<Types...>;
 
         /**
-         * @brief Construct an object of the corresponding tuple type.
+         * @brief The type at the given index in the range.
          *
-         * @tparam Args The types of arguments to forward to the tuple constructor.
-         * @param args The arguments to forward to the tuple constructor.
-         * @return Returns the constructed tuple.
+         * @tparam I The index of the type to access.
          */
-        template<typename... Args>
-        [[nodiscard]] static constexpr auto
-        make_tuple(Args&&... args) noexcept(std::is_nothrow_constructible_v<tuple, Args...>)
-            -> tuple;
-
-        /**
-         * @brief Construct an object of the corresponding variant type.
-         *
-         * @tparam Args The types of arguments to forward to the variant constructor.
-         * @param args The arguments to forward to the variant constructor.
-         * @return Returns the constructed variant.
-         */
-        template<typename... Args>
-        [[nodiscard]] static constexpr auto
-        make_variant(Args&&... args) noexcept(std::is_nothrow_constructible_v<variant, Args...>)
-            -> variant;
-    };
-
-    /**
-     * @brief Empty type list.
-     *
-     * An empty type list lacks the `front`, `back`, and `at` members.
-     */
-    template<>
-    struct list<> {
-    public:
-        /**
-         * @brief The number of elements in the list.
-         *
-         * @{
-         */
-        using size  = std::integral_constant<std::size_t, 0>;
-        using ssize = std::integral_constant<std::make_signed_t<std::size_t>, 0>;
-        //! @}
-
-        /**
-         * @brief Whether the list is empty or not.
-         */
-        using empty = std::true_type;
-
-        /**
-         * @brief The tuple type that has the listed types as its elements.
-         */
-        using tuple = std::tuple<>;
-
-        /**
-         * @brief The variant type that has the listed types as its alternatives.
-         */
-        using variant = std::variant<>;
+        template<std::size_t I>
+            requires(I < size())
+        using at = std::tuple_element_t<I, tuple>;
 
         /**
          * @brief Construct an object of the corresponding tuple type.
@@ -343,6 +277,14 @@ namespace posu::meta {
     template<list_type List, std::size_t I>
         requires(I < typename List::size())
     using at = typename List::template at<I>;
+
+    template<list_type List>
+        requires(!typename List::empty())
+    using front = at<List, 0>;
+
+    template<list_type List>
+        requires(!typename List::empty())
+    using back = at<List, typename List::size() - 1>;
 
     /**
      * @brief Find the index of the first ocurrence of the given type.

--- a/posu/meta/ratio.hpp
+++ b/posu/meta/ratio.hpp
@@ -7,6 +7,13 @@
 
 namespace posu::meta {
 
+    namespace detail {
+
+        template<typename Lhs, typename Rhs>
+        [[nodiscard]] constexpr bool ratio_equal(Lhs lhs, Rhs rhs) noexcept;
+
+    }
+
     /**
      * @brief A ratio between type products.
      *
@@ -19,6 +26,27 @@ namespace posu::meta {
         using den = Denominator; //!< The denominator type list.
 
         using type = ratio<num, den>; //!< Self-alias.
+
+        /**
+         * @brief Equality comparison between two type ratios.
+         *
+         * Two type ratios are equal if, in their reduced forms, each operand's numerator contains
+         * the same types as the other's denominator, in any order.
+         *
+         * @tparam RNum The numerator of the right-hand-side ratio to compare.
+         * @tparam RDen The deominator of the right-hand-side ratio to compare.
+         *
+         * @param lhs The left-hand-side comparison operand.
+         * @param rhs The right-hand-size comparison operand.
+         *
+         * @return true  Both type ratios are equivalent.
+         * @return false The type ratios are not equivalent.
+         */
+        template<list_type RNum, list_type RDen>
+        [[nodiscard]] friend constexpr bool operator==(ratio lhs, ratio<RNum, RDen> rhs) noexcept
+        {
+            return detail::ratio_equal(lhs, rhs);
+        }
     };
 
     /**

--- a/posu/meta/ratio.hpp
+++ b/posu/meta/ratio.hpp
@@ -97,22 +97,6 @@ namespace posu::meta {
     };
 
     /**
-     * @brief Obtain the numerator of the given type ratio.
-     *
-     * @tparam T The type ratio to get the numerator of.
-     */
-    template<ratio_type T>
-    using numerator = std::remove_const_t<decltype(T::num)>;
-
-    /**
-     * @brief Obtain the denominator of the given type ratio.
-     *
-     * @tparam T The type ratio to get the denominator of.
-     */
-    template<ratio_type T>
-    using denominator = std::remove_const_t<decltype(T::den)>;
-
-    /**
      * @brief Obtain the inverse of the given type ratio.
      *
      * @param r The type ratio to invert.

--- a/posu/meta/ratio.hpp
+++ b/posu/meta/ratio.hpp
@@ -13,7 +13,7 @@ namespace posu::meta {
      * @tparam Numerator   The list of types in the numerator.
      * @tparam Denominator The list of types in the denominator.
      */
-    template<typename Numerator = list<>, typename Denominator = list<>>
+    template<list_type Numerator = list<>, list_type Denominator = list<>>
     struct ratio {
         using num = Numerator;   //!< The numerator type list.
         using den = Denominator; //!< The denominator type list.

--- a/posu/meta/ratio.hpp
+++ b/posu/meta/ratio.hpp
@@ -100,10 +100,6 @@ namespace posu::meta {
 
     } // namespace detail
 
-    template<ratio_type Ratio>
-    using ratio_invert =
-        ratio<std::remove_const_t<decltype(Ratio::den)>, std::remove_const_t<decltype(Ratio::num)>>;
-
     /**
      * @brief Multiply two type ratios together.
      *

--- a/posu/meta/ratio.hpp
+++ b/posu/meta/ratio.hpp
@@ -33,7 +33,9 @@ namespace posu::meta {
     namespace detail
     {
 
-        [[nodiscard]] constexpr bool ratio_equal(ratio_type auto lhs, ratio_type auto rhs) noexcept;
+        [[nodiscard]] constexpr auto ratio_multiply(
+            ratio_type auto lhs,
+            ratio_type auto rhs) noexcept;
 
     } // namespace detail
 
@@ -51,6 +53,32 @@ namespace posu::meta {
         using type = ratio<Numerator, Denominator>; //!< Self-alias.
 
         /**
+         * @brief Multiply two type ratios together.
+         *
+         * @param lhs The left-hand-side operand.
+         * @param rhs The right-hand-side operand.
+         *
+         * @return Returns the multiplication result.
+         */
+        [[nodiscard]] friend constexpr auto operator*(ratio lhs, ratio_type auto rhs) noexcept
+        {
+            return detail::ratio_multiply(lhs, rhs);
+        }
+
+        /**
+         * @brief Divide one type ratios by another.
+         *
+         * @param num The type ratio to divide.
+         * @param den The type ratio to divide by.
+         *
+         * @return Returns the division result.
+         */
+        [[nodiscard]] friend constexpr auto operator/(ratio num, ratio_type auto den) noexcept
+        {
+            return num * invert(den);
+        }
+
+        /**
          * @brief Equality comparison between two type ratios.
          *
          * Two type ratios are equal if, in their reduced forms, each operand's numerator contains
@@ -64,7 +92,7 @@ namespace posu::meta {
          */
         [[nodiscard]] friend constexpr bool operator==(ratio lhs, ratio_type auto rhs) noexcept
         {
-            return detail::ratio_equal(lhs, rhs);
+            return std::same_as<decltype(lhs / rhs), ratio<>>;
         }
     };
 
@@ -92,26 +120,6 @@ namespace posu::meta {
      * @return Returns the inverted type ratio.
      */
     [[nodiscard]] constexpr auto invert(ratio_type auto r) noexcept;
-
-    /**
-     * @brief Multiply two type ratios together.
-     *
-     * @param lhs The left-hand-side operand.
-     * @param rhs The right-hand-side operand.
-     *
-     * @return Returns the multiplication result.
-     */
-    [[nodiscard]] constexpr auto ratio_multiply(ratio_type auto lhs, ratio_type auto rhs) noexcept;
-
-    /**
-     * @brief Divide one type ratios by another.
-     *
-     * @param num The type ratio to divide.
-     * @param den The type ratio to divide by.
-     *
-     * @return Returns the division result.
-     */
-    [[nodiscard]] constexpr auto ratio_divide(ratio_type auto num, ratio_type auto den) noexcept;
 
 } // namespace posu::meta
 

--- a/posu/meta/ratio.hpp
+++ b/posu/meta/ratio.hpp
@@ -88,10 +88,11 @@ namespace posu::meta {
     /**
      * @brief Obtain the inverse of the given type ratio.
      *
-     * @tparam T The type ratio to get the inverse of.
+     * @param r The type ratio to invert.
+     *
+     * @return Returns the inverted type ratio.
      */
-    template<ratio_type T>
-    using inverse = ratio<denominator<T>, numerator<T>>;
+    [[nodiscard]] constexpr auto invert(ratio_type auto r) noexcept;
 
     namespace detail {
 
@@ -116,7 +117,7 @@ namespace posu::meta {
      * @tparam Divisor  The type ratio to divide by.
      */
     template<typename Dividend, typename Divisor>
-    using ratio_divide = ratio_multiply<Dividend, inverse<Divisor>>;
+    using ratio_divide = ratio_multiply<Dividend, decltype(invert(Divisor{}))>;
 
 } // namespace posu::meta
 

--- a/posu/meta/ratio.hpp
+++ b/posu/meta/ratio.hpp
@@ -33,8 +33,7 @@ namespace posu::meta {
     namespace detail
     {
 
-        template<ratio_type Lhs, ratio_type Rhs>
-        [[nodiscard]] constexpr bool ratio_equal(Lhs lhs, Rhs rhs) noexcept;
+        [[nodiscard]] constexpr bool ratio_equal(ratio_type auto lhs, ratio_type auto rhs) noexcept;
 
     } // namespace detail
 
@@ -94,30 +93,25 @@ namespace posu::meta {
      */
     [[nodiscard]] constexpr auto invert(ratio_type auto r) noexcept;
 
-    namespace detail {
-
-        template<typename Lhs, typename Rhs>
-        struct ratio_multiply_impl;
-
-    } // namespace detail
-
     /**
      * @brief Multiply two type ratios together.
      *
-     * @tparam Lhs The left-hand-size operand.
-     * @tparam Rhs The right-hand-side operand.
+     * @param lhs The left-hand-side operand.
+     * @param rhs The right-hand-side operand.
+     *
+     * @return Returns the multiplication result.
      */
-    template<typename Lhs, typename Rhs>
-    using ratio_multiply = typename detail::ratio_multiply_impl<Lhs, Rhs>::type;
+    [[nodiscard]] constexpr auto ratio_multiply(ratio_type auto lhs, ratio_type auto rhs) noexcept;
 
     /**
      * @brief Divide one type ratios by another.
      *
-     * @tparam Dividend The type ratio to divide.
-     * @tparam Divisor  The type ratio to divide by.
+     * @param num The type ratio to divide.
+     * @param den The type ratio to divide by.
+     *
+     * @return Returns the division result.
      */
-    template<typename Dividend, typename Divisor>
-    using ratio_divide = ratio_multiply<Dividend, decltype(invert(Divisor{}))>;
+    [[nodiscard]] constexpr auto ratio_divide(ratio_type auto num, ratio_type auto den) noexcept;
 
 } // namespace posu::meta
 

--- a/posu/meta/ratio.hpp
+++ b/posu/meta/ratio.hpp
@@ -46,10 +46,10 @@ namespace posu::meta {
      */
     template<list_type Numerator, list_type Denominator>
     struct ratio {
-        using num = Numerator;   //!< The numerator type list.
-        using den = Denominator; //!< The denominator type list.
+        static constexpr auto num = Numerator{};   //!< The numerator type list.
+        static constexpr auto den = Denominator{}; //!< The denominator type list.
 
-        using type = ratio<num, den>; //!< Self-alias.
+        using type = ratio<Numerator, Denominator>; //!< Self-alias.
 
         /**
          * @brief Equality comparison between two type ratios.
@@ -75,7 +75,7 @@ namespace posu::meta {
      * @tparam T The type ratio to get the numerator of.
      */
     template<ratio_type T>
-    using numerator = typename T::num;
+    using numerator = std::remove_const_t<decltype(T::num)>;
 
     /**
      * @brief Obtain the denominator of the given type ratio.
@@ -83,7 +83,7 @@ namespace posu::meta {
      * @tparam T The type ratio to get the denominator of.
      */
     template<ratio_type T>
-    using denominator = typename T::den;
+    using denominator = std::remove_const_t<decltype(T::den)>;
 
     /**
      * @brief Obtain the inverse of the given type ratio.
@@ -101,7 +101,8 @@ namespace posu::meta {
     } // namespace detail
 
     template<ratio_type Ratio>
-    using ratio_invert = ratio<typename Ratio::den, typename Ratio::num>;
+    using ratio_invert =
+        ratio<std::remove_const_t<decltype(Ratio::den)>, std::remove_const_t<decltype(Ratio::num)>>;
 
     /**
      * @brief Multiply two type ratios together.

--- a/posu/units/dimension.hpp
+++ b/posu/units/dimension.hpp
@@ -21,7 +21,7 @@ namespace posu::units {
     };
 
     template<typename T>
-    concept derived_dimension = meta::is_ratio_v<T> && meta::all_of<is_base_dimension>(
+    concept derived_dimension = meta::ratio_type<T> && meta::all_of<is_base_dimension>(
         typename T::num{}) && meta::all_of<is_base_dimension>(typename T::den{});
 
     template<typename T>

--- a/posu/units/dimension.hpp
+++ b/posu/units/dimension.hpp
@@ -76,13 +76,13 @@ namespace posu::units {
                 return meta::ratio<meta::list<Lhs, Rhs>>{};
             }
             else if constexpr(base_dimension<Lhs> && derived_dimension<Rhs>) {
-                return meta::ratio_multiply<meta::ratio<meta::list<Lhs>>, Rhs>{};
+                return meta::ratio_multiply(meta::ratio<meta::list<Lhs>>{}, Rhs{});
             }
             else if constexpr(derived_dimension<Lhs> && base_dimension<Rhs>) {
-                return meta::ratio_multiply<Lhs, meta::ratio<meta::list<Rhs>>>{};
+                return meta::ratio_multiply(Lhs{}, meta::ratio<meta::list<Rhs>>{});
             }
             else {
-                return meta::ratio_multiply<Lhs, Rhs>{};
+                return meta::ratio_multiply(Lhs{}, Rhs{});
             }
         }
 

--- a/posu/units/dimension.hpp
+++ b/posu/units/dimension.hpp
@@ -76,13 +76,13 @@ namespace posu::units {
                 return meta::ratio<meta::list<Lhs, Rhs>>{};
             }
             else if constexpr(base_dimension<Lhs> && derived_dimension<Rhs>) {
-                return meta::ratio_multiply(meta::ratio<meta::list<Lhs>>{}, Rhs{});
+                return meta::ratio<meta::list<Lhs>>{} * Rhs{};
             }
             else if constexpr(derived_dimension<Lhs> && base_dimension<Rhs>) {
-                return meta::ratio_multiply(Lhs{}, meta::ratio<meta::list<Rhs>>{});
+                return Lhs{} * meta::ratio<meta::list<Rhs>>{};
             }
             else {
-                return meta::ratio_multiply(Lhs{}, Rhs{});
+                return Lhs{} * Rhs{};
             }
         }
 

--- a/posu/units/dimension.hpp
+++ b/posu/units/dimension.hpp
@@ -90,12 +90,10 @@ namespace posu::units {
         [[nodiscard]] constexpr auto dimension_divide_impl() noexcept
         {
             if constexpr(base_dimension<Rhs>) {
-                return dimension_multiply_impl<
-                    Lhs,
-                    meta::ratio_invert<meta::ratio<meta::list<Rhs>>>>();
+                return dimension_multiply_impl<Lhs, meta::inverse<meta::ratio<meta::list<Rhs>>>>();
             }
             else {
-                return dimension_multiply_impl<Lhs, meta::ratio_invert<Rhs>>();
+                return dimension_multiply_impl<Lhs, meta::inverse<Rhs>>();
             }
         }
 

--- a/posu/units/dimension.hpp
+++ b/posu/units/dimension.hpp
@@ -90,10 +90,12 @@ namespace posu::units {
         [[nodiscard]] constexpr auto dimension_divide_impl() noexcept
         {
             if constexpr(base_dimension<Rhs>) {
-                return dimension_multiply_impl<Lhs, meta::inverse<meta::ratio<meta::list<Rhs>>>>();
+                return dimension_multiply_impl<
+                    Lhs,
+                    decltype(meta::invert(meta::ratio<meta::list<Rhs>>{}))>();
             }
             else {
-                return dimension_multiply_impl<Lhs, meta::inverse<Rhs>>();
+                return dimension_multiply_impl<Lhs, decltype(meta::invert(Rhs{}))>();
             }
         }
 

--- a/posu/units/dimension.hpp
+++ b/posu/units/dimension.hpp
@@ -21,8 +21,8 @@ namespace posu::units {
     };
 
     template<typename T>
-    concept derived_dimension = meta::ratio_type<T> && meta::all_of<is_base_dimension>(
-        typename T::num{}) && meta::all_of<is_base_dimension>(typename T::den{});
+    concept derived_dimension = meta::ratio_type<T> &&
+        meta::all_of<is_base_dimension>(T::num) && meta::all_of<is_base_dimension>(T::den);
 
     template<typename T>
     concept dimension = base_dimension<T> || derived_dimension<T>;

--- a/test/meta/test_list.cpp
+++ b/test/meta/test_list.cpp
@@ -47,21 +47,15 @@ TEST_CASE("range operations", "[algorithms]")
 
     SECTION("pushing types")
     {
-        using original = meta::list<>;
+        constexpr auto original = meta::list<>{};
 
-        using add_one   = meta::push_back<original, int>;
-        using add_two   = meta::push_back<add_one, double>;
-        using add_three = meta::push_front<add_two, long double>;
+        constexpr auto add_one   = meta::push_back<int>(original);
+        constexpr auto add_two   = meta::push_back<double>(add_one);
+        constexpr auto add_three = meta::push_front<long double>(add_two);
 
-        static_assert(std::same_as<add_one, meta::list<int>>);
-        static_assert(std::same_as<add_two, meta::list<int, double>>);
-        static_assert(std::same_as<add_three, meta::list<long double, int, double>>);
-        static_assert(std::same_as<
-                      meta::push_front<add_three, meta::list<char>>,
-                      meta::push_front<add_three, char>>);
-        static_assert(std::same_as<
-                      meta::push_back<add_three, meta::list<char>>,
-                      meta::push_back<add_three, char>>);
+        static_assert(add_one == meta::list<int>{});
+        static_assert(add_two == meta::list<int, double>{});
+        static_assert(add_three == meta::list<long double, int, double>{});
     }
 
     SECTION("popping types")

--- a/test/meta/test_list.cpp
+++ b/test/meta/test_list.cpp
@@ -71,13 +71,13 @@ TEST_CASE("range operations", "[algorithms]")
 
     SECTION("finding types")
     {
-        using list = meta::list<char, int, int, long, float, double>;
+        constexpr auto list = meta::list<char, int, int, long, float, double>{};
 
-        REQUIRE(meta::find<list, char>() == 0);
-        REQUIRE(meta::find<list, int>() == 1);
-        REQUIRE(meta::find<list, long>() == 3);
-        REQUIRE(meta::find<list, float>() == 4);
-        REQUIRE(meta::find<list, double>() == 5);
+        REQUIRE(meta::find<char>(list) == 0);
+        REQUIRE(meta::find<int>(list) == 1);
+        REQUIRE(meta::find<long>(list) == 3);
+        REQUIRE(meta::find<float>(list) == 4);
+        REQUIRE(meta::find<double>(list) == 5);
     }
 
     SECTION("sub-lists")

--- a/test/meta/test_list.cpp
+++ b/test/meta/test_list.cpp
@@ -84,28 +84,26 @@ TEST_CASE("range operations", "[algorithms]")
     {
         SECTION("first N elements")
         {
-            using list = meta::list<char, int, long, float, double>;
+            constexpr auto list = meta::list<char, int, long, float, double>{};
 
-            static_assert(std::same_as<meta::first<list, 0>, meta::list<>>);
-            static_assert(std::same_as<meta::first<list, 1>, meta::list<char>>);
-            static_assert(std::same_as<meta::first<list, 2>, meta::list<char, int>>);
-            static_assert(std::same_as<meta::first<list, 3>, meta::list<char, int, long>>);
-            static_assert(std::same_as<meta::first<list, 4>, meta::list<char, int, long, float>>);
-            static_assert(
-                std::same_as<meta::first<list, 5>, meta::list<char, int, long, float, double>>);
+            static_assert(meta::first<0>(list) == meta::list<>{});
+            static_assert(meta::first<1>(list) == meta::list<char>{});
+            static_assert(meta::first<2>(list) == meta::list<char, int>{});
+            static_assert(meta::first<3>(list) == meta::list<char, int, long>{});
+            static_assert(meta::first<4>(list) == meta::list<char, int, long, float>{});
+            static_assert(meta::first<5>(list) == meta::list<char, int, long, float, double>{});
         }
 
         SECTION("last N elements")
         {
-            using list = meta::list<char, int, long, float, double>;
+            constexpr auto list = meta::list<char, int, long, float, double>{};
 
-            static_assert(std::same_as<meta::last<list, 0>, meta::list<>>);
-            static_assert(std::same_as<meta::last<list, 1>, meta::list<double>>);
-            static_assert(std::same_as<meta::last<list, 2>, meta::list<float, double>>);
-            static_assert(std::same_as<meta::last<list, 3>, meta::list<long, float, double>>);
-            static_assert(std::same_as<meta::last<list, 4>, meta::list<int, long, float, double>>);
-            static_assert(
-                std::same_as<meta::last<list, 5>, meta::list<char, int, long, float, double>>);
+            static_assert(meta::last<0>(list) == meta::list<>{});
+            static_assert(meta::last<1>(list) == meta::list<double>{});
+            static_assert(meta::last<2>(list) == meta::list<float, double>{});
+            static_assert(meta::last<3>(list) == meta::list<long, float, double>{});
+            static_assert(meta::last<4>(list) == meta::list<int, long, float, double>{});
+            static_assert(meta::last<5>(list) == meta::list<char, int, long, float, double>{});
         }
     }
 

--- a/test/meta/test_list.cpp
+++ b/test/meta/test_list.cpp
@@ -60,13 +60,13 @@ TEST_CASE("range operations", "[algorithms]")
 
     SECTION("popping types")
     {
-        using list = meta::list<char, int, long, float, double>;
+        constexpr auto list = meta::list<char, int, long, float, double>{};
 
-        using pop_one = meta::pop_front<list>;
-        using pop_two = meta::pop_back<pop_one>;
+        constexpr auto pop_one = meta::pop_front(list);
+        constexpr auto pop_two = meta::pop_back(pop_one);
 
-        static_assert(std::same_as<pop_one, meta::list<int, long, float, double>>);
-        static_assert(std::same_as<pop_two, meta::list<int, long, float>>);
+        static_assert(pop_one == meta::list<int, long, float, double>{});
+        static_assert(pop_two == meta::list<int, long, float>{});
     }
 
     SECTION("finding types")

--- a/test/meta/test_list.cpp
+++ b/test/meta/test_list.cpp
@@ -26,9 +26,9 @@ TEST_CASE("initialization", "[construct]")
     REQUIRE(list::size() == 6);
     REQUIRE(!list::empty());
 
-    static_assert(std::same_as<list::front, int>, "the first element must be an int");
+    static_assert(std::same_as<meta::front<list>, int>, "the first element must be an int");
     static_assert(
-        std::same_as<list::back, const double&>,
+        std::same_as<meta::back<list>, const double&>,
         "the last element must be const double&");
 }
 

--- a/test/meta/test_list.cpp
+++ b/test/meta/test_list.cpp
@@ -12,23 +12,24 @@ namespace {
 
 TEST_CASE("initialization", "[construct]")
 {
-    using list = meta::list<int, float, double, int&, float&&, const double&>;
+    using list_t        = meta::list<int, float, double, int&, float&&, const double&>;
+    constexpr auto list = list_t{};
 
-    static_assert(std::same_as<list::at<0>, int>, "the first element must be int");
-    static_assert(std::same_as<list::at<1>, float>, "the second element must be float");
-    static_assert(std::same_as<list::at<2>, double>, "the third element must be double");
-    static_assert(std::same_as<list::at<3>, int&>, "the fourth element must be int&");
-    static_assert(std::same_as<list::at<4>, float&&>, "the fifth element must be float&&");
+    static_assert(std::same_as<list_t::at<0>, int>, "the first element must be int");
+    static_assert(std::same_as<list_t::at<1>, float>, "the second element must be float");
+    static_assert(std::same_as<list_t::at<2>, double>, "the third element must be double");
+    static_assert(std::same_as<list_t::at<3>, int&>, "the fourth element must be int&");
+    static_assert(std::same_as<list_t::at<4>, float&&>, "the fifth element must be float&&");
     static_assert(
-        std::same_as<list::at<5>, const double&>,
+        std::same_as<list_t::at<5>, const double&>,
         "the sixth element must be const double&");
 
-    REQUIRE(list::size() == 6);
-    REQUIRE(!list::empty());
+    REQUIRE(list.size() == 6);
+    REQUIRE(!list.empty());
 
-    static_assert(std::same_as<meta::front<list>, int>, "the first element must be an int");
+    static_assert(std::same_as<meta::front<list_t>, int>, "the first element must be an int");
     static_assert(
-        std::same_as<meta::back<list>, const double&>,
+        std::same_as<meta::back<list_t>, const double&>,
         "the last element must be const double&");
 }
 
@@ -41,8 +42,9 @@ TEST_CASE("range operations", "[algorithms]")
 
         constexpr auto result = meta::concatenate(lhs, rhs);
 
-        static_assert(result == meta::list<int, float, double, unsigned int, unsigned char>{});
-        static_assert(meta::concatenate(lhs, rhs, lhs, rhs) == meta::concatenate(result, lhs, rhs));
+        CHECK(result == meta::list<int, float, double, unsigned int, unsigned char>{});
+        CHECK(result != lhs);
+        CHECK(meta::concatenate(lhs, rhs, lhs, rhs) == meta::concatenate(result, lhs, rhs));
     }
 
     SECTION("pushing types")

--- a/test/meta/test_list.cpp
+++ b/test/meta/test_list.cpp
@@ -36,16 +36,13 @@ TEST_CASE("range operations", "[algorithms]")
 {
     SECTION("concatenation")
     {
-        using lhs = meta::list<int, float, double>;
-        using rhs = meta::list<unsigned int, unsigned char>;
+        constexpr auto lhs = meta::list<int, float, double>{};
+        constexpr auto rhs = meta::list<unsigned int, unsigned char>{};
 
-        using result = meta::concatenate<lhs, rhs>;
+        constexpr auto result = meta::concatenate(lhs, rhs);
 
-        static_assert(
-            std::same_as<result, meta::list<int, float, double, unsigned int, unsigned char>>);
-        static_assert(std::same_as<
-                      meta::concatenate<lhs, rhs, lhs, rhs>,
-                      meta::concatenate<result, lhs, rhs>>);
+        static_assert(result == meta::list<int, float, double, unsigned int, unsigned char>{});
+        static_assert(meta::concatenate(lhs, rhs, lhs, rhs) == meta::concatenate(result, lhs, rhs));
     }
 
     SECTION("pushing types")

--- a/test/meta/test_list.cpp
+++ b/test/meta/test_list.cpp
@@ -109,26 +109,20 @@ TEST_CASE("range operations", "[algorithms]")
 
     SECTION("inserting types")
     {
-        using list = meta::list<char, int, long, float, double>;
+        constexpr auto list = meta::list<char, int, long, float, double>{};
 
-        static_assert(std::same_as<
-                      meta::insert<list, 0, int>,
-                      meta::list<int, char, int, long, float, double>>);
-        static_assert(std::same_as<
-                      meta::insert<list, 1, int>,
-                      meta::list<char, int, int, long, float, double>>);
-        static_assert(std::same_as<
-                      meta::insert<list, 2, int>,
-                      meta::list<char, int, int, long, float, double>>);
-        static_assert(std::same_as<
-                      meta::insert<list, 3, int>,
-                      meta::list<char, int, long, int, float, double>>);
-        static_assert(std::same_as<
-                      meta::insert<list, 4, int>,
-                      meta::list<char, int, long, float, int, double>>);
-        static_assert(std::same_as<
-                      meta::insert<list, 5, int>,
-                      meta::list<char, int, long, float, double, int>>);
+        static_assert(
+            meta::insert<0, int>(list) == meta::list<int, char, int, long, float, double>{});
+        static_assert(
+            meta::insert<1, int>(list) == meta::list<char, int, int, long, float, double>{});
+        static_assert(
+            meta::insert<2, int>(list) == meta::list<char, int, int, long, float, double>{});
+        static_assert(
+            meta::insert<3, int>(list) == meta::list<char, int, long, int, float, double>{});
+        static_assert(
+            meta::insert<4, int>(list) == meta::list<char, int, long, float, int, double>{});
+        static_assert(
+            meta::insert<5, int>(list) == meta::list<char, int, long, float, double, int>{});
     }
 
     SECTION("removing types")

--- a/test/meta/test_list.cpp
+++ b/test/meta/test_list.cpp
@@ -78,6 +78,12 @@ TEST_CASE("range operations", "[algorithms]")
         REQUIRE(meta::find<long>(list) == 3);
         REQUIRE(meta::find<float>(list) == 4);
         REQUIRE(meta::find<double>(list) == 5);
+
+        REQUIRE(meta::contains<char>(list));
+        REQUIRE(meta::contains<int>(list));
+        REQUIRE(meta::contains<long>(list));
+        REQUIRE(meta::contains<float>(list));
+        REQUIRE(meta::contains<double>(list));
     }
 
     SECTION("sub-lists")

--- a/test/meta/test_list.cpp
+++ b/test/meta/test_list.cpp
@@ -127,13 +127,23 @@ TEST_CASE("range operations", "[algorithms]")
 
     SECTION("removing types")
     {
-        using list = meta::list<char, int, long, float, double>;
+        constexpr auto list = meta::list<char, int, long, float, double>{};
 
-        static_assert(std::same_as<meta::remove<list, 0>, meta::list<int, long, float, double>>);
-        static_assert(std::same_as<meta::remove<list, 1>, meta::list<char, long, float, double>>);
-        static_assert(std::same_as<meta::remove<list, 2>, meta::list<char, int, float, double>>);
-        static_assert(std::same_as<meta::remove<list, 3>, meta::list<char, int, long, double>>);
-        static_assert(std::same_as<meta::remove<list, 4>, meta::list<char, int, long, float>>);
+        static_assert(meta::remove<0>(list) == meta::list<int, long, float, double>{});
+        static_assert(meta::remove<1>(list) == meta::list<char, long, float, double>{});
+        static_assert(meta::remove<2>(list) == meta::list<char, int, float, double>{});
+        static_assert(meta::remove<3>(list) == meta::list<char, int, long, double>{});
+        static_assert(meta::remove<4>(list) == meta::list<char, int, long, float>{});
+
+        static_assert(meta::remove_range<0, 0>(list) == meta::list<int, long, float, double>{});
+        static_assert(meta::remove_range<0, 1>(list) == meta::list<long, float, double>{});
+        static_assert(meta::remove_range<0, 2>(list) == meta::list<float, double>{});
+        static_assert(meta::remove_range<1, 1>(list) == meta::list<char, long, float, double>{});
+        static_assert(meta::remove_range<1, 2>(list) == meta::list<char, float, double>{});
+        static_assert(meta::remove_range<1, 3>(list) == meta::list<char, double>{});
+        static_assert(meta::remove_range<2, 2>(list) == meta::list<char, int, float, double>{});
+        static_assert(meta::remove_range<2, 3>(list) == meta::list<char, int, double>{});
+        static_assert(meta::remove_range<2, 4>(list) == meta::list<char, int>{});
     }
 }
 

--- a/test/meta/test_ratio.cpp
+++ b/test/meta/test_ratio.cpp
@@ -31,11 +31,11 @@ TEMPLATE_TEST_CASE(
         meta::ratio<meta::list<double>, meta::list<int>>,
         meta::ratio<>>))
 {
-    using lhs     = std::tuple_element_t<0, TestType>;
-    using rhs     = std::tuple_element_t<1, TestType>;
-    using product = std::tuple_element_t<2, TestType>;
+    constexpr auto lhs     = std::tuple_element_t<0, TestType>{};
+    constexpr auto rhs     = std::tuple_element_t<1, TestType>{};
+    constexpr auto product = std::tuple_element_t<2, TestType>{};
 
-    static_assert(std::same_as<product, meta::ratio_multiply<lhs, rhs>>);
+    static_assert(product == meta::ratio_multiply(lhs, rhs));
 }
 
 TEMPLATE_TEST_CASE(
@@ -64,9 +64,9 @@ TEMPLATE_TEST_CASE(
         meta::ratio<meta::list<double>, meta::list<int>>,
         meta::ratio<meta::list<int, int>, meta::list<double, double>>>))
 {
-    using dividend = std::tuple_element_t<0, TestType>;
-    using divisor  = std::tuple_element_t<1, TestType>;
-    using quotient = std::tuple_element_t<2, TestType>;
+    constexpr auto dividend = std::tuple_element_t<0, TestType>{};
+    constexpr auto divisor  = std::tuple_element_t<1, TestType>{};
+    constexpr auto quotient = std::tuple_element_t<2, TestType>{};
 
-    static_assert(std::same_as<quotient, meta::ratio_divide<dividend, divisor>>);
+    static_assert(quotient == meta::ratio_divide(dividend, divisor));
 }

--- a/test/meta/test_ratio.cpp
+++ b/test/meta/test_ratio.cpp
@@ -35,7 +35,7 @@ TEMPLATE_TEST_CASE(
     constexpr auto rhs     = std::tuple_element_t<1, TestType>{};
     constexpr auto product = std::tuple_element_t<2, TestType>{};
 
-    static_assert(product == meta::ratio_multiply(lhs, rhs));
+    static_assert(product == lhs * rhs);
 }
 
 TEMPLATE_TEST_CASE(
@@ -68,5 +68,5 @@ TEMPLATE_TEST_CASE(
     constexpr auto divisor  = std::tuple_element_t<1, TestType>{};
     constexpr auto quotient = std::tuple_element_t<2, TestType>{};
 
-    static_assert(quotient == meta::ratio_divide(dividend, divisor));
+    static_assert(quotient == dividend / divisor);
 }


### PR DESCRIPTION
This change resolves #53 by reworking `meta` types to use function and operator syntax where possible instead of template syntax, improving both usage and header clarity.
- `meta::list`
    - replace template meta-functions with functions that return a `meta::list` value of the resulting type
    - introduce `meta::list_type` concept for instantiations of `meta::list`
    - make `front` and `back` non-members only
    - introduce `take`, `take_range`, and `remove_range` for sub-listing a `meta::list`
- `meta::ratio`
    - remove all meta-functions
    - introduce multiplication and division operators
    - introduce equality comparison operator
    - introduce `invert` normal function for inverting a ratio