### PR TITLE
feat(meta): automatic ratio reduction

### DIFF
--- a/posu/meta/ipp/list.ipp
+++ b/posu/meta/ipp/list.ipp
@@ -124,21 +124,23 @@ template<typename T, typename... Listed>
 }
 
 template<posu::meta::list_type List, std::size_t... I>
-[[nodiscard]] constexpr auto posu::meta::take(List l, std::index_sequence<I...> /*unused*/) noexcept
-    requires((I < l.size()) && ...)
+[[nodiscard]] constexpr auto
+posu::meta::take(List /*unused*/, std::index_sequence<I...> /*unused*/) noexcept
+    requires((I < List::size()) && ...)
 {
     return list<at<List, I>...>{};
 }
 
 template<std::size_t Begin, std::size_t End>
 [[nodiscard]] constexpr auto posu::meta::take_range(list_type auto l) noexcept
-    requires((Begin <= l.size()) && (End <= l.size()) && (Begin <= End))
+    requires((Begin <= decltype(l)::size()) && (End <= decltype(l)::size()) && (Begin <= End))
 {
     return take(l, detail::offset<Begin>(std::make_index_sequence<End - Begin>{}));
 }
 
 template<std::size_t N, typename... T>
-[[nodiscard]] constexpr auto posu::meta::first(list<T...> l) noexcept requires(N <= l.size())
+[[nodiscard]] constexpr auto posu::meta::first(list<T...> l) noexcept
+    requires(N <= list<T...>::size())
 {
     return take(l, std::make_index_sequence<N>{});
 }
@@ -164,7 +166,7 @@ template<std::size_t I, typename T>
 template<std::size_t... I>
 [[nodiscard]] constexpr auto
 posu::meta::remove(list_type auto l, std::index_sequence<I...> i) noexcept
-    requires((I < l.size()) && ...)
+    requires((I < decltype(l)::size()) && ...)
 {
     if constexpr(i.size() == 0) {
         return l;

--- a/posu/meta/list.hpp
+++ b/posu/meta/list.hpp
@@ -201,7 +201,7 @@ namespace posu::meta {
      */
     template<list_type List, std::size_t... I>
     [[nodiscard]] constexpr auto take(List l, std::index_sequence<I...> i = {}) noexcept
-        requires((I < l.size()) && ...);
+        requires((I < List::size()) && ...);
 
     /**
      * @brief Extract a sub-list from the given list.
@@ -215,7 +215,7 @@ namespace posu::meta {
      */
     template<std::size_t Begin, std::size_t End>
     [[nodiscard]] constexpr auto take_range(list_type auto l) noexcept
-        requires((Begin <= l.size()) && (End <= l.size()) && (Begin <= End));
+        requires((Begin <= decltype(l)::size()) && (End <= decltype(l)::size()) && (Begin <= End));
 
     /**
      * @brief Get the first `I` elements of the given list as a `list`.
@@ -224,7 +224,7 @@ namespace posu::meta {
      * @tparam I    The number of elements to get.
      */
     template<std::size_t N, typename... T>
-    [[nodiscard]] constexpr auto first(list<T...> l) noexcept requires(N <= l.size());
+    [[nodiscard]] constexpr auto first(list<T...> l) noexcept requires(N <= list<T...>::size());
 
     /**
      * @brief Get the last `I` elements of the given list as a `list`.
@@ -328,7 +328,7 @@ namespace posu::meta {
      */
     template<std::size_t... I>
     [[nodiscard]] constexpr auto remove(list_type auto l, std::index_sequence<I...> i = {}) noexcept
-        requires((I < l.size()) && ...);
+        requires((I < decltype(l)::size()) && ...);
 
     /**
      * @brief Remove a range of elements from the given type list.

--- a/posu/meta/ratio.hpp
+++ b/posu/meta/ratio.hpp
@@ -33,6 +33,7 @@ namespace posu::meta {
     namespace detail
     {
 
+        [[nodiscard]] constexpr auto ratio_reduce(list_type auto num, list_type auto den) noexcept;
         [[nodiscard]] constexpr auto ratio_multiply(
             ratio_type auto lhs,
             ratio_type auto rhs) noexcept;
@@ -47,10 +48,14 @@ namespace posu::meta {
      */
     template<list_type Numerator, list_type Denominator>
     struct ratio {
-        static constexpr auto num = Numerator{};   //!< The numerator type list.
-        static constexpr auto den = Denominator{}; //!< The denominator type list.
+    private:
+        using info = decltype(detail::ratio_reduce(Numerator{}, Denominator{}));
 
-        using type = ratio<Numerator, Denominator>; //!< Self-alias.
+    public:
+        static constexpr auto num = info::num; //!< The numerator type list.
+        static constexpr auto den = info::den; //!< The denominator type list.
+
+        using type = typename info::ratio_t; //!< Self-alias.
 
         /**
          * @brief Multiply two type ratios together.

--- a/test/meta/test_ratio.cpp
+++ b/test/meta/test_ratio.cpp
@@ -9,6 +9,39 @@ namespace {
 }
 
 TEMPLATE_TEST_CASE(
+    "automatic reduction",
+    "[ratio][reduce]",
+    (std::tuple<meta::ratio<meta::list<int>, meta::list<int>>, meta::ratio<>>),
+    (std::tuple<
+        meta::ratio<meta::list<int, double>, meta::list<int>>,
+        meta::ratio<meta::list<double>>>),
+    (std::tuple<
+        meta::ratio<meta::list<double, int>, meta::list<int>>,
+        meta::ratio<meta::list<double>>>),
+    (std::tuple<
+        meta::ratio<meta::list<int>, meta::list<int, double>>,
+        meta::ratio<meta::list<>, meta::list<double>>>),
+    (std::tuple<
+        meta::ratio<meta::list<int>, meta::list<double, int>>,
+        meta::ratio<meta::list<>, meta::list<double>>>))
+{
+    using original_t = std::tuple_element_t<0, TestType>;
+    using reduced_t  = std::tuple_element_t<1, TestType>;
+
+    STATIC_REQUIRE(!std::same_as<original_t, reduced_t>);
+    STATIC_REQUIRE(std::same_as<typename original_t::type, reduced_t>);
+    STATIC_REQUIRE(std::same_as<decltype(original_t::num), decltype(reduced_t::num)>);
+    STATIC_REQUIRE(std::same_as<decltype(original_t::den), decltype(reduced_t::den)>);
+
+    constexpr auto original = original_t{};
+    constexpr auto reduced  = reduced_t{};
+
+    STATIC_REQUIRE(original == reduced);
+    STATIC_REQUIRE(original.num == reduced.num);
+    STATIC_REQUIRE(original.den == reduced.den);
+}
+
+TEMPLATE_TEST_CASE(
     "multiplication",
     "[ratio][multiply]",
     (std::tuple<meta::ratio<>, meta::ratio<>, meta::ratio<>>),


### PR DESCRIPTION
`meta::ratio` members `num`, `den`, and `type` represent the fully-reduced ratio, just like `std::ratio`.